### PR TITLE
feat: deduplicate nutrition section and optimize print layout

### DIFF
--- a/docs/brainstorms/2026-02-24-nutrition-placement-print-layout-brainstorm.md
+++ b/docs/brainstorms/2026-02-24-nutrition-placement-print-layout-brainstorm.md
@@ -1,0 +1,76 @@
+# Nutrition Placement & Print Layout Optimization
+
+**Date:** 2026-02-24
+**Status:** Ready for planning
+
+## What We're Building
+
+Two related improvements to recipe pages:
+
+1. **Remove duplicate nutrition section** — Currently `NutritionCard` renders twice on desktop: full-size after instructions (main column) and compact in the sidebar (under ingredients). Keep sidebar-only placement; remove the full-size duplicate from `RecipeContent`.
+
+2. **Optimize print layout for 1-page fit** — Aggressively reduce heading sizes, step number sizing, spacing, and remove non-essential content so the core recipe (title, meta, ingredients, instructions) fits on a single printed page for most recipes.
+
+## Why This Approach
+
+- **Sidebar nutrition** pairs naturally with ingredients (both are reference data you glance at while cooking)
+- **Removing the main-column nutrition** eliminates scroll redundancy on desktop without losing information
+- **1-page print** is the #1 user expectation for printed recipes — nobody wants to flip pages while cooking
+- **Ingredients-first print order** matches the natural cooking flow (gather, then cook)
+
+## Key Decisions
+
+### Nutrition Placement
+| Decision | Choice |
+|----------|--------|
+| Desktop | Compact `NutritionCard` in sidebar only (under ingredients) |
+| Mobile/Tablet | Show nutrition inline after ingredients (existing `lg:hidden` block) |
+| Print | Hide nutrition entirely (save space for ingredients + instructions) |
+| JSON-LD | No change — `RecipeSchema.astro` still includes nutrition in structured data |
+
+### Print Layout
+| Decision | Choice |
+|----------|--------|
+| Target | Core recipe fits 1 page for most recipes |
+| Content order | Title/Meta → Ingredients → Instructions → Source URL |
+| Hidden in print | AuthorBioCard, NutritionCard, hero image, blog prose, nav, footer, FAQ, related recipes, date night tips, ToC, share/jump buttons (already hidden) |
+| Heading sizes | Override to ~12pt for h2, ~11pt for h3 in `@media print` |
+| Step numbers | Shrink from 32x32px circles to ~20x20px or inline numbers |
+| Step spacing | Reduce from `space-y-6` (1.5rem) to tighter spacing in print |
+| Page margins | Keep 1.5cm (already set) |
+| Body font | Keep 11pt (already set) |
+
+## Scope of Changes
+
+### Files to Modify
+
+1. **`src/components/RecipeContent.astro`**
+   - Remove the `NutritionCard` render (lines 80-85)
+   - Remove `NutritionCard` import
+   - Remove `nutrition` from Props interface and destructuring
+   - Add print styles for compact headings, step numbers, spacing
+
+2. **`src/pages/en/recipes/[...slug].astro`** (and FR equivalent)
+   - Remove `nutrition` prop from `RecipeContent` usage
+   - Add `no-print` to `AuthorBioCard` wrapper
+   - Add nutrition to the inline mobile ingredient block (so mobile users still see it)
+   - Add print CSS to reorder ingredients before instructions
+
+3. **`src/pages/fr/recettes/[...slug].astro`**
+   - Same changes as EN page
+
+4. **`src/styles/global.css`**
+   - Add print heading size overrides (h2 → 12pt, h3 → 11pt)
+   - Add print step-number size reduction
+   - Add print spacing compression
+   - Add `.recipe-sidebar` display override for print (show sidebar ingredients, or use CSS `order` to move inline ingredients above instructions)
+
+5. **`src/components/NutritionCard.astro`**
+   - No changes needed (compact mode stays for sidebar use)
+
+6. **`src/components/InstructionSteps.astro`**
+   - Possibly add print-specific classes for step number sizing
+
+## Open Questions
+
+None — all decisions resolved.

--- a/docs/plans/2026-02-24-feat-nutrition-placement-print-layout-plan.md
+++ b/docs/plans/2026-02-24-feat-nutrition-placement-print-layout-plan.md
@@ -1,0 +1,341 @@
+---
+title: "feat: Deduplicate nutrition section and optimize print layout for 1-page fit"
+type: feat
+status: completed
+date: 2026-02-24
+origin: docs/brainstorms/2026-02-24-nutrition-placement-print-layout-brainstorm.md
+---
+
+# Deduplicate Nutrition Section & Optimize Print Layout
+
+## Overview
+
+Two related improvements to recipe pages:
+1. **Remove duplicate NutritionCard** — keep sidebar-only (desktop) and inline (mobile), remove full-size from RecipeContent
+2. **Optimize print layout** — fit core recipe on one page by shrinking headings/spacing, reordering ingredients before instructions, and hiding non-essential content
+
+## Problem Statement / Motivation
+
+- **Nutrition duplication**: On desktop, users see NutritionCard twice — full-size after instructions (RecipeContent) and compact in sidebar. Redundant and adds scroll.
+- **Print layout**: Recipes often spill to 2 pages because headings are too large (`text-heading-2` = 30px, `text-heading-3` = 24px), step numbers are 32x32px circles, spacing is generous (`space-y-6`), and non-essential content (AuthorBioCard, NutritionCard) prints. Ingredients also appear AFTER instructions due to DOM order.
+
+## Proposed Solution
+
+### Part 1: Nutrition Consolidation
+
+| Context | Before | After |
+|---------|--------|-------|
+| Desktop (>= lg) | Full-size in main column + compact in sidebar | Compact in sidebar only |
+| Mobile (< lg) | Full-size in main column | Compact in inline ingredients block |
+| Print | Full-size in main column | Hidden entirely |
+| JSON-LD | In RecipeSchema | No change |
+
+### Part 2: Print Layout Optimization
+
+| Aspect | Before | After |
+|--------|--------|-------|
+| Content order | Instructions → Nutrition → Ingredients | **Ingredients → Instructions** |
+| Sidebar in print | Hidden (`display: none` from `hidden` class) | Forced visible via `display: block !important` |
+| Inline mobile block | Visible in print | Hidden in print (avoid duplicate ingredients) |
+| Headings | 30px/24px (Tailwind sizes) | ~12pt h2, ~11pt h3 |
+| Step numbers | 32x32px terracotta circles | Small inline numbers, no background circle |
+| Step spacing | `space-y-6` (1.5rem) | `space-y-2` equivalent |
+| AuthorBioCard | Prints | Hidden (`no-print`) |
+| NutritionCard | Prints (full-size) | Hidden (`no-print`) |
+| Sidebar decorative styles | Borders, bg, padding, rounded | Stripped for ink/space savings |
+| Grid gap | `gap-8` (2rem) | Reduced in print |
+
+**Acceptance criteria for "1 page"**: Optimize for typical recipes (~10 ingredients, ~6 steps). Longer recipes may overflow to 2 pages — that's acceptable.
+
+## Technical Considerations
+
+### CSS Print Mechanics
+
+The key challenge is forcing the sidebar visible and reordering it before the main column:
+
+1. `.recipe-sidebar` has `hidden lg:block` → `display: none` at base. Print doesn't trigger `lg:`, so sidebar stays hidden. Must add `display: block !important` in print.
+2. `.recipe-two-col` is forced to `display: block !important` in print. For reordering with `order`, need `display: flex !important; flex-direction: column !important` instead.
+3. `.recipe-sidebar` gets `order: -1 !important` to appear before main column.
+4. Inline mobile ingredients block (`.lg\:hidden` outside grid) must be hidden in print to avoid duplicate ingredients.
+5. Sidebar inner container has `rounded-xl border border-gray-200 bg-white p-5` + inline `max-height` — all waste space/ink in print. Strip them.
+6. Step number circles use `bg-brand-primary-dark` (#A85D3D) — not overridden in existing print CSS. Replace with plain inline numbers.
+7. `gap-8` on `.recipe-two-col` adds 2rem between sidebar and main in flex — reduce to 0 or minimal.
+
+### EN/FR File Synchronization
+
+Both `src/pages/en/recipes/[...slug].astro` and `src/pages/fr/recettes/[...slug].astro` are near-identical. All template changes must be mirrored exactly in both files.
+
+## Acceptance Criteria
+
+### Nutrition Placement
+- [x] Desktop: NutritionCard appears only in sidebar (compact)
+- [x] Mobile: NutritionCard appears in inline ingredients block (compact)
+- [x] Print: NutritionCard does not appear anywhere
+- [x] Recipes without nutrition data: no NutritionCard renders in any context (conditional preserved)
+- [x] EN and FR pages have identical behavior
+
+### Print Layout
+- [x] Print order: Title/Meta → Ingredients → Instructions → Source URL
+- [x] AuthorBioCard hidden in print
+- [x] NutritionCard hidden in print (both sidebar and inline)
+- [x] Sidebar forced visible in print with decorative styles stripped
+- [x] Inline mobile ingredients block hidden in print
+- [x] Headings reduced to ~12pt (h2) and ~11pt (h3)
+- [x] Step numbers rendered as small inline text, no background circles
+- [x] Step spacing tightened
+- [ ] Typical recipe (~10 ingredients, ~6 steps) fits on 1 printed page
+- [ ] Long recipes overflow gracefully to page 2
+
+### Cleanup
+- [x] `NutritionCard` import removed from `RecipeContent.astro`
+- [x] `nutrition` prop removed from `RecipeContent` Props interface and destructuring
+- [x] `ingredientGroups` prop removed from `RecipeContent` Props (already unused)
+- [x] `nutrition` and `ingredientGroups` props removed from `<RecipeContent>` usage in slug pages
+- [x] `.step-image` print hide rule moved from `RecipeContent.astro` scoped style to `global.css`
+
+## MVP
+
+### 1. `src/components/RecipeContent.astro`
+
+Remove NutritionCard, clean up unused props, move `.step-image` rule out:
+
+```astro
+---
+import { t, type Locale } from "@i18n/utils";
+import { formatDuration } from "@utils/format";
+import InstructionSteps from "./InstructionSteps.astro";
+
+interface Props {
+  locale: Locale;
+  title: string;
+  prepTime: string;
+  cookTime: string;
+  totalTime: string;
+  recipeYield: string;
+  difficulty: "easy" | "medium" | "hard";
+  instructionGroups: InstructionGroup[];
+  sourceUrl: string;
+}
+
+// ... destructure without nutrition or ingredientGroups
+---
+
+<div id="recipe" class="scroll-mt-20">
+  <!-- Print-only header (unchanged) -->
+  ...
+
+  <!-- Instructions -->
+  <InstructionSteps locale={locale} instructionGroups={instructionGroups} />
+
+  <!-- NutritionCard REMOVED from here -->
+
+  <!-- Print-only source URL (unchanged) -->
+  ...
+</div>
+
+<style>
+  .print-only {
+    display: none;
+  }
+
+  @media print {
+    .print-only {
+      display: block;
+    }
+    /* .step-image rule MOVED to global.css */
+  }
+</style>
+```
+
+### 2. `src/pages/en/recipes/[...slug].astro` (and FR equivalent)
+
+Remove unused props from RecipeContent, add NutritionCard to inline block, add `no-print` wrappers:
+
+```astro
+<!-- RecipeContent: remove nutrition and ingredientGroups props -->
+<RecipeContent
+  locale={locale}
+  title={data.title}
+  prepTime={data.prepTime}
+  cookTime={data.cookTime}
+  totalTime={data.totalTime}
+  recipeYield={data.recipeYield}
+  difficulty={data.difficulty}
+  instructionGroups={data.instructionGroups}
+  sourceUrl={sourceUrl}
+/>
+
+<!-- Sidebar: wrap NutritionCard with no-print -->
+<aside class="recipe-sidebar hidden lg:block">
+  <div class="sticky top-[73px] space-y-6 ...">
+    <div class="rounded-lg bg-gray-100 p-4 ...">
+      <IngredientList ... />
+    </div>
+    {data.nutrition && (
+      <div class="no-print">
+        <NutritionCard locale={locale} nutrition={data.nutrition} compact={true} />
+      </div>
+    )}
+  </div>
+</aside>
+
+<!-- Inline ingredients: add NutritionCard, add class for print hiding -->
+<div class="recipe-inline-ingredients mx-auto mt-8 max-w-prose rounded-xl bg-gray-50 p-6 lg:hidden dark:bg-neutral-800/30">
+  <IngredientList locale={locale} ingredientGroups={data.ingredientGroups} idPrefix="inline-ing" />
+  {data.nutrition && (
+    <div class="mt-4 no-print">
+      <NutritionCard locale={locale} nutrition={data.nutrition} compact={true} />
+    </div>
+  )}
+</div>
+
+<!-- AuthorBioCard: wrap with no-print -->
+<div class="mt-8 no-print">
+  <AuthorBioCard locale={locale} />
+</div>
+```
+
+### 3. `src/styles/global.css` — Print Overrides
+
+```css
+@media print {
+  /* ... existing rules ... */
+
+  /* Step images hidden in print (moved from RecipeContent.astro scoped style) */
+  .step-image {
+    display: none !important;
+  }
+
+  /* Force sidebar visible and reorder before main column */
+  .recipe-two-col {
+    display: flex !important;
+    flex-direction: column !important;
+    gap: 0.5rem !important;
+  }
+
+  .recipe-sidebar {
+    display: block !important;
+    order: -1 !important;
+    position: static !important;
+    max-height: none !important;
+  }
+
+  /* Strip sidebar decorative styles for ink/space savings */
+  .recipe-sidebar > div {
+    border: none !important;
+    background: none !important;
+    padding: 0 !important;
+    border-radius: 0 !important;
+    max-height: none !important;
+    overflow: visible !important;
+  }
+
+  .recipe-sidebar .rounded-lg {
+    background: none !important;
+    padding: 0 !important;
+    border-radius: 0 !important;
+  }
+
+  /* Hide inline mobile ingredients in print (sidebar ingredients shown instead) */
+  .recipe-inline-ingredients {
+    display: none !important;
+  }
+
+  /* Compact headings for print */
+  h2 {
+    font-size: 12pt !important;
+    margin-bottom: 0.3rem !important;
+    margin-top: 0.5rem !important;
+    break-after: avoid;
+  }
+
+  h3 {
+    font-size: 11pt !important;
+    margin-bottom: 0.2rem !important;
+    margin-top: 0.3rem !important;
+    break-after: avoid;
+  }
+
+  /* Compact step numbers: plain inline text instead of circles */
+  .step-number {
+    width: auto !important;
+    height: auto !important;
+    background: none !important;
+    color: #000 !important;
+    font-size: 10pt !important;
+    padding: 0 !important;
+    border-radius: 0 !important;
+  }
+
+  .step-number::after {
+    content: ".";
+  }
+
+  /* Tighten step spacing */
+  .instruction-steps ol {
+    gap: 0.25rem !important;
+  }
+
+  .instruction-steps li {
+    gap: 0.25rem !important;
+  }
+
+  /* Tighten ingredient spacing */
+  .recipe-sidebar ul {
+    gap: 0.15rem !important;
+  }
+}
+```
+
+### 4. `src/components/InstructionSteps.astro`
+
+Add semantic classes for print targeting:
+
+```astro
+<!-- Add class to section for print targeting -->
+<section class="instruction-steps">
+  ...
+  <!-- Add class to step number span -->
+  <span aria-hidden="true" class="step-number flex h-8 w-8 shrink-0 ...">
+    {i + 1}
+  </span>
+  ...
+</section>
+```
+
+## Files to Modify
+
+| File | Changes |
+|------|---------|
+| `src/components/RecipeContent.astro` | Remove NutritionCard import/render/props, clean up unused ingredientGroups prop, remove scoped `.step-image` print rule |
+| `src/pages/en/recipes/[...slug].astro` | Remove nutrition/ingredientGroups props from RecipeContent, add NutritionCard to inline block, wrap sidebar NutritionCard + AuthorBioCard with `no-print`, add `recipe-inline-ingredients` class |
+| `src/pages/fr/recettes/[...slug].astro` | Mirror all EN changes exactly |
+| `src/styles/global.css` | Add print overrides: sidebar visibility + order, heading sizes, step number styling, spacing, decorative style stripping, inline block hiding, `.step-image` rule |
+| `src/components/InstructionSteps.astro` | Add `instruction-steps` class to section, `step-number` class to step number span |
+
+## Success Metrics
+
+- Desktop: NutritionCard appears once (sidebar compact) — no duplicate
+- Mobile: NutritionCard appears once (inline compact) — was full-size before
+- Print: A 10-ingredient / 6-step recipe fits on 1 page in Chrome print preview
+- `npm run check` passes with no errors
+- `npm run build` succeeds
+
+## Dependencies & Risks
+
+- **Low risk**: All changes are CSS + template-level. No data model or schema changes.
+- **EN/FR sync**: Must mirror template changes in both slug page files. Test both.
+- **Print rendering differences**: Chrome, Safari, and Firefox render print CSS differently. Test in at least Chrome.
+- **Long recipes**: Accept that recipes with 15+ ingredients and 10+ steps may overflow to 2 pages.
+
+## Sources & References
+
+- **Origin brainstorm:** [docs/brainstorms/2026-02-24-nutrition-placement-print-layout-brainstorm.md](docs/brainstorms/2026-02-24-nutrition-placement-print-layout-brainstorm.md) — Key decisions: sidebar-only nutrition, 1-page print target, ingredients-first order, hide AuthorBio + Nutrition in print
+- `src/components/NutritionCard.astro` — compact vs full-size modes
+- `src/components/RecipeContent.astro:80-85` — NutritionCard to remove
+- `src/pages/en/recipes/[...slug].astro:204-216` — sidebar structure
+- `src/pages/en/recipes/[...slug].astro:220-222` — inline ingredients block
+- `src/styles/global.css:100-172` — existing print stylesheet
+- `tailwind.config.mjs:25-33` — custom heading sizes
+- CLAUDE.md Lesson #14: hero images need `max-h-[350px] object-cover`
+- CLAUDE.md Lesson #5: never pair `uppercase` with negative `letter-spacing`

--- a/src/components/InstructionSteps.astro
+++ b/src/components/InstructionSteps.astro
@@ -21,7 +21,7 @@ interface Props {
 const { locale, instructionGroups } = Astro.props;
 ---
 
-<section>
+<section class="instruction-steps">
   <h2 class="mb-6 font-heading text-heading-2 font-bold text-gray-900 dark:text-neutral-100">
     {t(locale, "recipe.instructions")}
   </h2>
@@ -33,7 +33,7 @@ const { locale, instructionGroups } = Astro.props;
       <ol class="space-y-6">
         {group.steps.map((step, i) => (
           <li class="flex gap-4">
-            <span aria-hidden="true" class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-brand-primary-dark font-ui text-sm font-bold text-white">
+            <span aria-hidden="true" class="step-number flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-brand-primary-dark font-ui text-sm font-bold text-white">
               {i + 1}
             </span>
             <div class="pt-0.5">

--- a/src/components/JumpToRecipe.astro
+++ b/src/components/JumpToRecipe.astro
@@ -10,7 +10,7 @@ const { locale } = Astro.props;
 
 <a
   href="#recipe"
-  class="no-print inline-flex items-center gap-2 rounded-lg bg-brand-accent px-6 py-3 font-ui text-sm font-semibold text-gray-900 no-underline shadow-sm transition-all hover:bg-brand-accent-dark hover:shadow-md"
+  class="no-print inline-flex items-center gap-2 rounded-lg bg-brand-accent px-6 py-3 font-ui text-sm font-semibold !text-white no-underline shadow-sm transition-all hover:bg-brand-accent-dark hover:!text-white hover:shadow-md"
 >
   <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
     <path stroke-linecap="round" stroke-linejoin="round" d="M19 14l-7 7m0 0l-7-7m7 7V3" />

--- a/src/components/RecipeContent.astro
+++ b/src/components/RecipeContent.astro
@@ -2,7 +2,6 @@
 import { t, type Locale } from "@i18n/utils";
 import { formatDuration } from "@utils/format";
 import InstructionSteps from "./InstructionSteps.astro";
-import NutritionCard from "./NutritionCard.astro";
 import type { ImageMetadata } from "astro";
 
 interface HowToStep {
@@ -10,21 +9,9 @@ interface HowToStep {
   image?: ImageMetadata;
 }
 
-interface IngredientGroup {
-  group?: string;
-  items: string[];
-}
-
 interface InstructionGroup {
   group?: string;
   steps: HowToStep[];
-}
-
-interface Nutrition {
-  calories?: string;
-  fatContent?: string;
-  carbohydrateContent?: string;
-  proteinContent?: string;
 }
 
 interface Props {
@@ -35,9 +22,7 @@ interface Props {
   totalTime: string;
   recipeYield: string;
   difficulty: "easy" | "medium" | "hard";
-  ingredientGroups: IngredientGroup[];
   instructionGroups: InstructionGroup[];
-  nutrition?: Nutrition;
   sourceUrl: string;
 }
 
@@ -50,7 +35,6 @@ const {
   recipeYield,
   difficulty,
   instructionGroups,
-  nutrition,
   sourceUrl,
 } = Astro.props;
 
@@ -77,13 +61,6 @@ const difficultyLabels = {
   <!-- Instructions -->
   <InstructionSteps locale={locale} instructionGroups={instructionGroups} />
 
-  <!-- Nutrition (full width) -->
-  {nutrition && (
-    <div class="mt-8">
-      <NutritionCard locale={locale} nutrition={nutrition} />
-    </div>
-  )}
-
   <!-- Print-only source URL -->
   <footer class="print-only border-t border-gray-300 pt-3 text-center text-xs text-gray-500">
     {t(locale, "recipe.source")}: {sourceUrl}
@@ -98,10 +75,6 @@ const difficultyLabels = {
   @media print {
     .print-only {
       display: block;
-    }
-
-    .step-image {
-      display: none;
     }
   }
 </style>

--- a/src/pages/en/recipes/[...slug].astro
+++ b/src/pages/en/recipes/[...slug].astro
@@ -193,9 +193,7 @@ const difficultyColors = {
           totalTime={data.totalTime}
           recipeYield={data.recipeYield}
           difficulty={data.difficulty}
-          ingredientGroups={data.ingredientGroups}
           instructionGroups={data.instructionGroups}
-          nutrition={data.nutrition}
           sourceUrl={sourceUrl}
         />
       </div>
@@ -210,15 +208,22 @@ const difficultyColors = {
 
           <!-- Nutrition (compact) -->
           {data.nutrition && (
-            <NutritionCard locale={locale} nutrition={data.nutrition} compact={true} />
+            <div class="no-print">
+              <NutritionCard locale={locale} nutrition={data.nutrition} compact={true} />
+            </div>
           )}
         </div>
       </aside>
     </div>
 
     <!-- Inline ingredients (mobile/tablet only) — hidden on lg -->
-    <div class="mx-auto mt-8 max-w-prose rounded-xl bg-gray-50 p-6 lg:hidden dark:bg-neutral-800/30">
+    <div class="recipe-inline-ingredients mx-auto mt-8 max-w-prose rounded-xl bg-gray-50 p-6 lg:hidden dark:bg-neutral-800/30">
       <IngredientList locale={locale} ingredientGroups={data.ingredientGroups} idPrefix="inline-ing" />
+      {data.nutrition && (
+        <div class="mt-4 no-print">
+          <NutritionCard locale={locale} nutrition={data.nutrition} compact={true} />
+        </div>
+      )}
     </div>
 
     <!-- Full-width zone: bottom sections -->
@@ -228,7 +233,7 @@ const difficultyColors = {
       )}
 
       <!-- Author Bio -->
-      <div class="mt-8">
+      <div class="mt-8 no-print">
         <AuthorBioCard locale={locale} />
       </div>
 

--- a/src/pages/fr/recettes/[...slug].astro
+++ b/src/pages/fr/recettes/[...slug].astro
@@ -193,9 +193,7 @@ const difficultyColors = {
           totalTime={data.totalTime}
           recipeYield={data.recipeYield}
           difficulty={data.difficulty}
-          ingredientGroups={data.ingredientGroups}
           instructionGroups={data.instructionGroups}
-          nutrition={data.nutrition}
           sourceUrl={sourceUrl}
         />
       </div>
@@ -210,15 +208,22 @@ const difficultyColors = {
 
           <!-- Nutrition (compact) -->
           {data.nutrition && (
-            <NutritionCard locale={locale} nutrition={data.nutrition} compact={true} />
+            <div class="no-print">
+              <NutritionCard locale={locale} nutrition={data.nutrition} compact={true} />
+            </div>
           )}
         </div>
       </aside>
     </div>
 
     <!-- Inline ingredients (mobile/tablet only) — hidden on lg -->
-    <div class="mx-auto mt-8 max-w-prose rounded-xl bg-gray-50 p-6 lg:hidden dark:bg-neutral-800/30">
+    <div class="recipe-inline-ingredients mx-auto mt-8 max-w-prose rounded-xl bg-gray-50 p-6 lg:hidden dark:bg-neutral-800/30">
       <IngredientList locale={locale} ingredientGroups={data.ingredientGroups} idPrefix="inline-ing" />
+      {data.nutrition && (
+        <div class="mt-4 no-print">
+          <NutritionCard locale={locale} nutrition={data.nutrition} compact={true} />
+        </div>
+      )}
     </div>
 
     <!-- Full-width zone: bottom sections -->
@@ -228,7 +233,7 @@ const difficultyColors = {
       )}
 
       <!-- Author Bio -->
-      <div class="mt-8">
+      <div class="mt-8 no-print">
         <AuthorBioCard locale={locale} />
       </div>
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -134,19 +134,89 @@
     color: #000 !important;
   }
 
-  /* Force single column for print (two-column recipe layout) */
+  /* Step images hidden in print */
+  .step-image {
+    display: none !important;
+  }
+
+  /* Force single column with sidebar (ingredients) before main content */
   .recipe-two-col {
-    display: block !important;
+    display: flex !important;
+    flex-direction: column !important;
+    gap: 0.5rem !important;
+    max-width: none !important;
   }
 
   .recipe-sidebar {
+    display: block !important;
+    order: -1 !important;
     position: static !important;
     max-height: none !important;
   }
 
-  /* Page break rules */
-  h2, h3 {
+  /* Strip sidebar decorative styles for ink/space savings */
+  .recipe-sidebar > div {
+    border: none !important;
+    background: none !important;
+    padding: 0 !important;
+    border-radius: 0 !important;
+    max-height: none !important;
+    overflow: visible !important;
+  }
+
+  .recipe-sidebar .rounded-lg {
+    background: none !important;
+    padding: 0 !important;
+    border-radius: 0 !important;
+  }
+
+  /* Hide inline mobile ingredients in print (sidebar ingredients shown instead) */
+  .recipe-inline-ingredients {
+    display: none !important;
+  }
+
+  /* Compact headings for print */
+  h2 {
+    font-size: 12pt !important;
+    margin-top: 0.5rem !important;
+    margin-bottom: 0.3rem !important;
     break-after: avoid;
+  }
+
+  h3 {
+    font-size: 11pt !important;
+    margin-top: 0.3rem !important;
+    margin-bottom: 0.2rem !important;
+    break-after: avoid;
+  }
+
+  /* Compact step numbers: plain inline text instead of circles */
+  .step-number {
+    width: auto !important;
+    height: auto !important;
+    background: none !important;
+    color: #000 !important;
+    font-size: 10pt !important;
+    padding: 0 !important;
+    border-radius: 0 !important;
+  }
+
+  .step-number::after {
+    content: ".";
+  }
+
+  /* Tighten step spacing */
+  .instruction-steps ol {
+    gap: 0.25rem !important;
+  }
+
+  .instruction-steps li {
+    gap: 0.25rem !important;
+  }
+
+  /* Tighten ingredient spacing */
+  .recipe-sidebar ul {
+    gap: 0.15rem !important;
   }
 
   li {


### PR DESCRIPTION
## Summary
- **Remove duplicate NutritionCard** — was showing both in sidebar (compact) and after instructions (full-size) on desktop. Now sidebar-only on desktop, inline on mobile, hidden in print.
- **Optimize print layout for 1-page fit** — sidebar forced visible and reordered before instructions, headings shrunk to 12pt/11pt, step numbers changed from 32px circles to plain text, spacing tightened, AuthorBioCard hidden, sidebar decorative styles stripped.
- **Fix Jump to Recipe button** — white text on both normal and hover states (global anchor styles were overriding).

## Files Changed
| File | Changes |
|------|---------|
| `src/components/RecipeContent.astro` | Removed NutritionCard import/render/props, cleaned up unused `ingredientGroups` prop, moved `.step-image` print rule to global.css |
| `src/components/InstructionSteps.astro` | Added `instruction-steps` and `step-number` classes for print CSS targeting |
| `src/components/JumpToRecipe.astro` | Fixed text color to `!text-white` / `hover:!text-white` |
| `src/pages/en/recipes/[...slug].astro` | Removed unused props from RecipeContent, added NutritionCard to inline mobile block, wrapped sidebar NutritionCard + AuthorBioCard with `no-print`, added `recipe-inline-ingredients` class |
| `src/pages/fr/recettes/[...slug].astro` | Mirrored all EN changes |
| `src/styles/global.css` | Print overrides: flex column layout with sidebar first, compact headings/step numbers/spacing, decorative style stripping |

## Test plan
- [ ] Desktop: verify NutritionCard appears only in sidebar (compact), not after instructions
- [ ] Mobile: verify NutritionCard appears in inline ingredients block (compact)
- [ ] Print preview (Cmd+P): verify ingredients appear before instructions, no nutrition/author bio, compact headings and step numbers
- [ ] Print preview: typical recipe (~10 ingredients, ~6 steps) fits on 1 page
- [ ] Verify EN and FR pages have identical behavior
- [ ] Jump to Recipe button has white text on normal and hover states
- [ ] `npm run check` passes
- [ ] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)