### PR TITLE
feat: add privacy policy and terms of service (EN/FR)

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -25,6 +25,8 @@ categories.sort((a, b) => {
 
 const recipesPath = locale === "fr" ? "/recettes/" : "/recipes/";
 const aboutPath = locale === "fr" ? "/a-propos/" : "/about/";
+const privacyPath = locale === "fr" ? "/politique-de-confidentialite/" : "/privacy-policy/";
+const termsPath = locale === "fr" ? "/conditions-dutilisation/" : "/terms-of-service/";
 const categoryBasePath = locale === "fr" ? "/fr/recettes/categorie/" : "/en/recipes/category/";
 ---
 
@@ -88,11 +90,19 @@ const categoryBasePath = locale === "fr" ? "/fr/recettes/categorie/" : "/en/reci
         </nav>
       </div>
 
-      <!-- Tagline -->
-      <div class="flex flex-col justify-between">
-        <p aria-hidden="true" class="font-handwritten text-xl text-brand-primary/60 dark:text-brand-primary/40">
-          {t(locale, "site.tagline")}
-        </p>
+      <!-- Legal -->
+      <div>
+        <h3 class="mb-4 font-heading text-sm font-bold tracking-wider text-gray-900 dark:text-neutral-100">
+          {t(locale, "footer.legal")}
+        </h3>
+        <nav class="flex flex-col gap-2.5" aria-label={t(locale, "footer.legalNav")}>
+          <a href={getLocalizedPath(locale, privacyPath)} class="font-ui text-body-sm text-gray-600 no-underline transition-colors hover:text-brand-primary dark:text-neutral-400">
+            {t(locale, "privacy.pageTitle")}
+          </a>
+          <a href={getLocalizedPath(locale, termsPath)} class="font-ui text-body-sm text-gray-600 no-underline transition-colors hover:text-brand-primary dark:text-neutral-400">
+            {t(locale, "terms.pageTitle")}
+          </a>
+        </nav>
       </div>
     </div>
 

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -90,6 +90,8 @@
     "madeWith": "Made with love in Montreal",
     "categories": "Categories",
     "navigation": "Navigation",
+    "legal": "Legal",
+    "legalNav": "Legal navigation",
     "nav": "Footer navigation",
     "categoriesNav": "Recipe categories",
     "instagramLabel": "Follow us on Instagram"
@@ -129,6 +131,14 @@
     "bioShort": "Victor creates date night recipes designed to impress. Based in Montreal, he believes great food brings people closer together.",
     "aboutLink": "About the author",
     "photoAlt": "Victor, creator of Date My Dish"
+  },
+  "privacy": {
+    "title": "Privacy Policy",
+    "pageTitle": "Privacy Policy"
+  },
+  "terms": {
+    "title": "Terms of Service",
+    "pageTitle": "Terms of Service"
   },
   "lang": {
     "switchTo": "Français",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -90,6 +90,8 @@
     "madeWith": "Fait avec amour à Montréal",
     "categories": "Catégories",
     "navigation": "Navigation",
+    "legal": "Légal",
+    "legalNav": "Navigation légale",
     "nav": "Navigation du pied de page",
     "categoriesNav": "Catégories de recettes",
     "instagramLabel": "Suivez-nous sur Instagram"
@@ -129,6 +131,14 @@
     "bioShort": "Victor crée des recettes pour les soirées en amoureux, conçues pour impressionner. Basé à Montréal, il croit que la bonne cuisine rapproche les gens.",
     "aboutLink": "À propos de l'auteur",
     "photoAlt": "Victor, créateur de Date My Dish"
+  },
+  "privacy": {
+    "title": "Politique de confidentialité",
+    "pageTitle": "Politique de confidentialité"
+  },
+  "terms": {
+    "title": "Conditions d'utilisation",
+    "pageTitle": "Conditions d'utilisation"
   },
   "lang": {
     "switchTo": "English",

--- a/src/i18n/utils.ts
+++ b/src/i18n/utils.ts
@@ -60,6 +60,22 @@ export function getAlternateUrl(
     "a-propos": { en: "about", fr: "a-propos" },
     search: { en: "search", fr: "recherche" },
     recherche: { en: "search", fr: "recherche" },
+    "privacy-policy": {
+      en: "privacy-policy",
+      fr: "politique-de-confidentialite",
+    },
+    "politique-de-confidentialite": {
+      en: "privacy-policy",
+      fr: "politique-de-confidentialite",
+    },
+    "terms-of-service": {
+      en: "terms-of-service",
+      fr: "conditions-dutilisation",
+    },
+    "conditions-dutilisation": {
+      en: "terms-of-service",
+      fr: "conditions-dutilisation",
+    },
   };
 
   const translatedParts = pathParts.slice(1).map((part, index, arr) => {

--- a/src/pages/en/privacy-policy.astro
+++ b/src/pages/en/privacy-policy.astro
@@ -1,0 +1,142 @@
+---
+import BaseLayout from "@layouts/BaseLayout.astro";
+import Breadcrumbs from "@components/Breadcrumbs.astro";
+import { t } from "@i18n/utils";
+
+const locale = "en";
+---
+
+<BaseLayout
+  title={`${t(locale, "privacy.pageTitle")} | Date My Dish`}
+  description="Privacy Policy for Date My Dish. Learn how we collect, use, and protect your information when you visit our recipe blog."
+>
+  <div class="mx-auto max-w-narrow px-4 py-12 sm:py-16">
+    <Breadcrumbs
+      locale={locale}
+      items={[{ label: t(locale, "privacy.pageTitle") }]}
+    />
+
+    <div class="mb-10">
+      <h1 class="mb-3 font-heading text-heading-1 font-bold text-gray-900 sm:text-4xl dark:text-neutral-100">
+        {t(locale, "privacy.title")}
+      </h1>
+      <div class="h-1 w-12 rounded-full bg-brand-accent"></div>
+    </div>
+
+    <div class="prose max-w-none">
+      <p>
+        <strong>Last updated:</strong> February 26, 2026
+      </p>
+
+      <p>
+        Date My Dish ("we," "us," or "our") operates the website
+        <a href="https://www.datemydish.com">datemydish.com</a> (the "Site").
+        This Privacy Policy explains what information we collect, how we use it,
+        and your choices regarding that information.
+      </p>
+
+      <h2>Information We Collect</h2>
+
+      <h3>Analytics Data</h3>
+      <p>
+        We use <strong>Google Analytics</strong> and <strong>Cloudflare Web Analytics</strong> to
+        understand how visitors interact with the Site. These services may collect:
+      </p>
+      <ul>
+        <li>Pages visited and time spent on each page</li>
+        <li>Referring website or search terms that led you here</li>
+        <li>Browser type, operating system, and device type</li>
+        <li>Approximate geographic location (city/country level)</li>
+        <li>Anonymized IP address</li>
+      </ul>
+      <p>
+        Google Analytics uses cookies to distinguish unique visitors. Cloudflare Web Analytics
+        is privacy-first and does not use cookies or collect personal data. For more information,
+        see <a href="https://policies.google.com/privacy" target="_blank" rel="noopener noreferrer">Google's Privacy Policy</a>
+        and <a href="https://www.cloudflare.com/privacypolicy/" target="_blank" rel="noopener noreferrer">Cloudflare's Privacy Policy</a>.
+      </p>
+
+      <h3>Local Storage</h3>
+      <p>
+        We store your dark mode preference (<code>localStorage.theme</code>) in your browser's
+        local storage. This data never leaves your device and is not transmitted to our servers.
+      </p>
+
+      <h3>Third-Party Fonts</h3>
+      <p>
+        We load fonts from <strong>Google Fonts</strong>. When you visit the Site, your browser
+        makes a request to Google's servers to download font files. Google may log this request,
+        including your IP address. See
+        <a href="https://developers.google.com/fonts/faq/privacy" target="_blank" rel="noopener noreferrer">Google Fonts Privacy FAQ</a>
+        for details.
+      </p>
+
+      <h2>Cookies</h2>
+      <p>
+        We use cookies only through Google Analytics to distinguish unique visitors and track
+        site usage over time. These are first-party cookies set by the Google Analytics script.
+        You can opt out of Google Analytics by installing the
+        <a href="https://tools.google.com/dlpage/gaoptout" target="_blank" rel="noopener noreferrer">Google Analytics Opt-out Browser Add-on</a>.
+      </p>
+      <p>
+        You can also disable cookies entirely through your browser settings. The Site will
+        continue to function normally without cookies.
+      </p>
+
+      <h2>How We Use Information</h2>
+      <p>We use the analytics data we collect to:</p>
+      <ul>
+        <li>Understand which recipes and content are most popular</li>
+        <li>Improve site performance and user experience</li>
+        <li>Identify and fix technical issues</li>
+        <li>Make decisions about future content</li>
+      </ul>
+      <p>
+        We do not sell, trade, or otherwise transfer your information to third parties,
+        except as described in this policy (analytics providers).
+      </p>
+
+      <h2>Affiliate Links and Advertising</h2>
+      <p>
+        The Site may contain affiliate links and advertisements in the future. When we introduce
+        these, affiliate partners and ad networks may use cookies or similar technologies to
+        serve relevant content. This Privacy Policy will be updated accordingly at that time.
+      </p>
+
+      <h2>Data Retention</h2>
+      <p>
+        Analytics data is retained according to the default retention policies of Google Analytics
+        (26 months) and Cloudflare Web Analytics (6 months). We do not store any personal data
+        on our own servers.
+      </p>
+
+      <h2>Your Rights</h2>
+      <p>You have the right to:</p>
+      <ul>
+        <li>Opt out of Google Analytics tracking using the browser add-on linked above</li>
+        <li>Clear cookies and local storage through your browser settings</li>
+        <li>Request information about what data we hold (though we hold no personally identifiable data)</li>
+      </ul>
+
+      <h2>Children's Privacy</h2>
+      <p>
+        The Site is not directed at children under 13. We do not knowingly collect personal
+        information from children. If you believe a child has provided us with personal data,
+        please contact us so we can take appropriate action.
+      </p>
+
+      <h2>Changes to This Policy</h2>
+      <p>
+        We may update this Privacy Policy from time to time. Changes will be posted on this
+        page with an updated "Last updated" date. We encourage you to review this page
+        periodically.
+      </p>
+
+      <h2>Contact</h2>
+      <p>
+        If you have questions about this Privacy Policy, please reach out through our
+        <a href="/en/contact/">contact page</a>.
+      </p>
+    </div>
+  </div>
+</BaseLayout>

--- a/src/pages/en/terms-of-service.astro
+++ b/src/pages/en/terms-of-service.astro
@@ -1,0 +1,125 @@
+---
+import BaseLayout from "@layouts/BaseLayout.astro";
+import Breadcrumbs from "@components/Breadcrumbs.astro";
+import { t } from "@i18n/utils";
+
+const locale = "en";
+---
+
+<BaseLayout
+  title={`${t(locale, "terms.pageTitle")} | Date My Dish`}
+  description="Terms of Service for Date My Dish. Read the terms and conditions that govern your use of our recipe blog."
+>
+  <div class="mx-auto max-w-narrow px-4 py-12 sm:py-16">
+    <Breadcrumbs
+      locale={locale}
+      items={[{ label: t(locale, "terms.pageTitle") }]}
+    />
+
+    <div class="mb-10">
+      <h1 class="mb-3 font-heading text-heading-1 font-bold text-gray-900 sm:text-4xl dark:text-neutral-100">
+        {t(locale, "terms.title")}
+      </h1>
+      <div class="h-1 w-12 rounded-full bg-brand-accent"></div>
+    </div>
+
+    <div class="prose max-w-none">
+      <p>
+        <strong>Last updated:</strong> February 26, 2026
+      </p>
+
+      <p>
+        Welcome to Date My Dish. By accessing or using the website
+        <a href="https://www.datemydish.com">datemydish.com</a> (the "Site"), you agree to be
+        bound by these Terms of Service ("Terms"). If you do not agree to these Terms, please
+        do not use the Site.
+      </p>
+
+      <h2>Use of the Site</h2>
+      <p>
+        The Site provides recipes, cooking tips, and related content for personal, non-commercial
+        use. You may browse, save, and print recipes for your own personal enjoyment. You agree
+        not to:
+      </p>
+      <ul>
+        <li>Reproduce, distribute, or republish our content without written permission</li>
+        <li>Use automated tools to scrape or bulk-download content from the Site</li>
+        <li>Attempt to interfere with the Site's operation or security</li>
+        <li>Use the Site for any unlawful purpose</li>
+      </ul>
+
+      <h2>Intellectual Property</h2>
+      <p>
+        All content on the Site — including recipes, text, photographs, graphics, and design
+        — is owned by Date My Dish and protected by copyright and intellectual property laws.
+        You may share links to our pages freely, but reproducing our content (text, images,
+        or full recipes) on other websites or publications requires our prior written consent.
+      </p>
+
+      <h2>Recipe Disclaimer</h2>
+      <p>
+        Recipes on the Site are provided for informational and entertainment purposes. While
+        we strive for accuracy, we make no guarantees regarding:
+      </p>
+      <ul>
+        <li>Nutritional information (values are estimates and may vary)</li>
+        <li>Cooking times and temperatures (may differ based on equipment and conditions)</li>
+        <li>Allergen information (always verify ingredients if you have allergies or dietary restrictions)</li>
+        <li>Suitability for specific diets or medical conditions</li>
+      </ul>
+      <p>
+        You assume full responsibility for any use of the recipes and cooking instructions
+        provided on the Site.
+      </p>
+
+      <h2>Affiliate Links and Advertising</h2>
+      <p>
+        The Site may contain affiliate links and advertisements in the future. This means we may
+        earn a commission if you make a purchase through certain links, at no additional cost to you.
+        Affiliate relationships and sponsored content will always be clearly disclosed.
+      </p>
+
+      <h2>Third-Party Links</h2>
+      <p>
+        The Site may contain links to third-party websites. We are not responsible for the content,
+        privacy practices, or availability of those sites. Visiting third-party links is at your
+        own risk.
+      </p>
+
+      <h2>Disclaimer of Warranties</h2>
+      <p>
+        The Site is provided "as is" and "as available" without warranties of any kind, either
+        express or implied. We do not warrant that the Site will be uninterrupted, error-free,
+        or free of viruses or other harmful components.
+      </p>
+
+      <h2>Limitation of Liability</h2>
+      <p>
+        To the fullest extent permitted by law, Date My Dish shall not be liable for any indirect,
+        incidental, special, consequential, or punitive damages arising from your use of or
+        inability to use the Site, including but not limited to any errors in recipe content,
+        nutritional information, or cooking instructions.
+      </p>
+
+      <h2>Changes to These Terms</h2>
+      <p>
+        We reserve the right to modify these Terms at any time. Changes will be posted on this
+        page with an updated "Last updated" date. Your continued use of the Site after any
+        changes constitutes acceptance of the new Terms.
+      </p>
+
+      <h2>Governing Law</h2>
+      <p>
+        These Terms are governed by and construed in accordance with the laws of the Province
+        of Quebec and the federal laws of Canada applicable therein, without regard to conflict
+        of law principles.
+      </p>
+
+      <h2>Contact</h2>
+      <p>
+        If you have questions about these Terms, please reach out through our
+        <a href="/en/contact/">contact page</a>.
+      </p>
+    </div>
+  </div>
+</BaseLayout>

--- a/src/pages/fr/conditions-dutilisation.astro
+++ b/src/pages/fr/conditions-dutilisation.astro
@@ -1,0 +1,130 @@
+---
+import BaseLayout from "@layouts/BaseLayout.astro";
+import Breadcrumbs from "@components/Breadcrumbs.astro";
+import { t } from "@i18n/utils";
+
+const locale = "fr";
+---
+
+<BaseLayout
+  title={`${t(locale, "terms.pageTitle")} | Date My Dish`}
+  description="Conditions d'utilisation de Date My Dish. Lisez les modalités qui régissent votre utilisation de notre blogue de recettes."
+>
+  <div class="mx-auto max-w-narrow px-4 py-12 sm:py-16">
+    <Breadcrumbs
+      locale={locale}
+      items={[{ label: t(locale, "terms.pageTitle") }]}
+    />
+
+    <div class="mb-10">
+      <h1 class="mb-3 font-heading text-heading-1 font-bold text-gray-900 sm:text-4xl dark:text-neutral-100">
+        {t(locale, "terms.title")}
+      </h1>
+      <div class="h-1 w-12 rounded-full bg-brand-accent"></div>
+    </div>
+
+    <div class="prose max-w-none">
+      <p>
+        <strong>Dernière mise à jour :</strong> 26 février 2026
+      </p>
+
+      <p>
+        Bienvenue sur Date My Dish. En accédant ou en utilisant le site Web
+        <a href="https://www.datemydish.com">datemydish.com</a> (le « Site »), vous acceptez
+        d'être lié par les présentes conditions d'utilisation (les « Conditions »). Si vous
+        n'acceptez pas ces Conditions, veuillez ne pas utiliser le Site.
+      </p>
+
+      <h2>Utilisation du Site</h2>
+      <p>
+        Le Site fournit des recettes, des conseils culinaires et du contenu connexe à des fins
+        personnelles et non commerciales. Vous pouvez consulter, sauvegarder et imprimer les
+        recettes pour votre usage personnel. Vous vous engagez à ne pas :
+      </p>
+      <ul>
+        <li>Reproduire, distribuer ou republier notre contenu sans permission écrite</li>
+        <li>Utiliser des outils automatisés pour extraire ou télécharger en masse le contenu du Site</li>
+        <li>Tenter d'interférer avec le fonctionnement ou la sécurité du Site</li>
+        <li>Utiliser le Site à des fins illégales</li>
+      </ul>
+
+      <h2>Propriété intellectuelle</h2>
+      <p>
+        Tout le contenu du Site — y compris les recettes, les textes, les photographies, les
+        graphiques et le design — est la propriété de Date My Dish et est protégé par les lois
+        sur le droit d'auteur et la propriété intellectuelle. Vous pouvez partager librement
+        des liens vers nos pages, mais la reproduction de notre contenu (textes, images ou
+        recettes complètes) sur d'autres sites Web ou publications nécessite notre consentement
+        écrit préalable.
+      </p>
+
+      <h2>Avertissement concernant les recettes</h2>
+      <p>
+        Les recettes du Site sont fournies à titre informatif et de divertissement. Bien que
+        nous nous efforcions d'être exacts, nous ne garantissons pas :
+      </p>
+      <ul>
+        <li>Les informations nutritionnelles (les valeurs sont des estimations et peuvent varier)</li>
+        <li>Les temps et les températures de cuisson (peuvent différer selon l'équipement et les conditions)</li>
+        <li>Les informations sur les allergènes (vérifiez toujours les ingrédients si vous avez des allergies ou des restrictions alimentaires)</li>
+        <li>L'adéquation à des régimes alimentaires ou des conditions médicales spécifiques</li>
+      </ul>
+      <p>
+        Vous assumez l'entière responsabilité de toute utilisation des recettes et des
+        instructions de cuisson fournies sur le Site.
+      </p>
+
+      <h2>Liens d'affiliation et publicité</h2>
+      <p>
+        Le Site pourra contenir des liens d'affiliation et des publicités à l'avenir. Cela
+        signifie que nous pourrions recevoir une commission si vous effectuez un achat via
+        certains liens, sans frais supplémentaires pour vous. Les relations d'affiliation
+        et le contenu commandité seront toujours clairement divulgués.
+      </p>
+
+      <h2>Liens vers des tiers</h2>
+      <p>
+        Le Site peut contenir des liens vers des sites Web tiers. Nous ne sommes pas responsables
+        du contenu, des pratiques de confidentialité ou de la disponibilité de ces sites. La
+        consultation de liens tiers se fait à vos propres risques.
+      </p>
+
+      <h2>Exclusion de garanties</h2>
+      <p>
+        Le Site est fourni « tel quel » et « selon la disponibilité », sans garantie d'aucune
+        sorte, expresse ou implicite. Nous ne garantissons pas que le Site sera ininterrompu,
+        exempt d'erreurs ou libre de virus ou d'autres composants nuisibles.
+      </p>
+
+      <h2>Limitation de responsabilité</h2>
+      <p>
+        Dans toute la mesure permise par la loi, Date My Dish ne saurait être tenu responsable
+        de tout dommage indirect, accessoire, spécial, consécutif ou punitif découlant de votre
+        utilisation ou de votre incapacité à utiliser le Site, y compris, mais sans s'y limiter,
+        toute erreur dans le contenu des recettes, les informations nutritionnelles ou les
+        instructions de cuisson.
+      </p>
+
+      <h2>Modifications des Conditions</h2>
+      <p>
+        Nous nous réservons le droit de modifier les présentes Conditions à tout moment. Les
+        modifications seront publiées sur cette page avec une date de « Dernière mise à jour »
+        actualisée. Votre utilisation continue du Site après toute modification constitue une
+        acceptation des nouvelles Conditions.
+      </p>
+
+      <h2>Loi applicable</h2>
+      <p>
+        Les présentes Conditions sont régies et interprétées conformément aux lois de la province
+        de Québec et aux lois fédérales du Canada qui y sont applicables, sans égard aux principes
+        de conflits de lois.
+      </p>
+
+      <h2>Contact</h2>
+      <p>
+        Si vous avez des questions concernant ces Conditions, n'hésitez pas à nous écrire
+        via notre <a href="/fr/contact/">page de contact</a>.
+      </p>
+    </div>
+  </div>
+</BaseLayout>

--- a/src/pages/fr/politique-de-confidentialite.astro
+++ b/src/pages/fr/politique-de-confidentialite.astro
@@ -1,0 +1,147 @@
+---
+import BaseLayout from "@layouts/BaseLayout.astro";
+import Breadcrumbs from "@components/Breadcrumbs.astro";
+import { t } from "@i18n/utils";
+
+const locale = "fr";
+---
+
+<BaseLayout
+  title={`${t(locale, "privacy.pageTitle")} | Date My Dish`}
+  description="Politique de confidentialité de Date My Dish. Découvrez comment nous recueillons, utilisons et protégeons vos informations lorsque vous visitez notre blogue de recettes."
+>
+  <div class="mx-auto max-w-narrow px-4 py-12 sm:py-16">
+    <Breadcrumbs
+      locale={locale}
+      items={[{ label: t(locale, "privacy.pageTitle") }]}
+    />
+
+    <div class="mb-10">
+      <h1 class="mb-3 font-heading text-heading-1 font-bold text-gray-900 sm:text-4xl dark:text-neutral-100">
+        {t(locale, "privacy.title")}
+      </h1>
+      <div class="h-1 w-12 rounded-full bg-brand-accent"></div>
+    </div>
+
+    <div class="prose max-w-none">
+      <p>
+        <strong>Dernière mise à jour :</strong> 26 février 2026
+      </p>
+
+      <p>
+        Date My Dish (« nous » ou « notre ») exploite le site Web
+        <a href="https://www.datemydish.com">datemydish.com</a> (le « Site »).
+        La présente politique de confidentialité explique quelles informations nous recueillons,
+        comment nous les utilisons et les choix qui s'offrent à vous.
+      </p>
+
+      <h2>Informations recueillies</h2>
+
+      <h3>Données analytiques</h3>
+      <p>
+        Nous utilisons <strong>Google Analytics</strong> et <strong>Cloudflare Web Analytics</strong> pour
+        comprendre comment les visiteurs interagissent avec le Site. Ces services peuvent recueillir :
+      </p>
+      <ul>
+        <li>Les pages visitées et le temps passé sur chacune</li>
+        <li>Le site Web ou les termes de recherche qui vous ont mené ici</li>
+        <li>Le type de navigateur, le système d'exploitation et le type d'appareil</li>
+        <li>La localisation géographique approximative (ville/pays)</li>
+        <li>L'adresse IP anonymisée</li>
+      </ul>
+      <p>
+        Google Analytics utilise des témoins (cookies) pour distinguer les visiteurs uniques.
+        Cloudflare Web Analytics est axé sur la vie privée et n'utilise pas de témoins ni ne
+        recueille de données personnelles. Pour en savoir plus, consultez la
+        <a href="https://policies.google.com/privacy" target="_blank" rel="noopener noreferrer">politique de confidentialité de Google</a>
+        et la <a href="https://www.cloudflare.com/privacypolicy/" target="_blank" rel="noopener noreferrer">politique de confidentialité de Cloudflare</a>.
+      </p>
+
+      <h3>Stockage local</h3>
+      <p>
+        Nous enregistrons votre préférence de mode sombre (<code>localStorage.theme</code>) dans
+        le stockage local de votre navigateur. Ces données ne quittent jamais votre appareil et
+        ne sont pas transmises à nos serveurs.
+      </p>
+
+      <h3>Polices tierces</h3>
+      <p>
+        Nous chargeons des polices à partir de <strong>Google Fonts</strong>. Lorsque vous visitez
+        le Site, votre navigateur envoie une requête aux serveurs de Google pour télécharger les
+        fichiers de polices. Google peut enregistrer cette requête, y compris votre adresse IP.
+        Consultez la <a href="https://developers.google.com/fonts/faq/privacy" target="_blank" rel="noopener noreferrer">FAQ
+        sur la confidentialité de Google Fonts</a> pour plus de détails.
+      </p>
+
+      <h2>Témoins (Cookies)</h2>
+      <p>
+        Nous utilisons des témoins uniquement via Google Analytics pour distinguer les visiteurs
+        uniques et suivre l'utilisation du site au fil du temps. Il s'agit de témoins propriétaires
+        définis par le script Google Analytics. Vous pouvez refuser Google Analytics en installant
+        le <a href="https://tools.google.com/dlpage/gaoptout" target="_blank" rel="noopener noreferrer">module
+        complémentaire de désactivation de Google Analytics</a>.
+      </p>
+      <p>
+        Vous pouvez également désactiver les témoins entièrement dans les paramètres de votre
+        navigateur. Le Site continuera de fonctionner normalement sans témoins.
+      </p>
+
+      <h2>Utilisation des informations</h2>
+      <p>Nous utilisons les données analytiques recueillies pour :</p>
+      <ul>
+        <li>Comprendre quelles recettes et quel contenu sont les plus populaires</li>
+        <li>Améliorer la performance du site et l'expérience utilisateur</li>
+        <li>Identifier et corriger les problèmes techniques</li>
+        <li>Orienter nos décisions concernant le contenu futur</li>
+      </ul>
+      <p>
+        Nous ne vendons, n'échangeons ni ne transférons vos informations à des tiers,
+        sauf tel que décrit dans la présente politique (fournisseurs d'analytique).
+      </p>
+
+      <h2>Liens d'affiliation et publicité</h2>
+      <p>
+        Le Site pourra contenir des liens d'affiliation et des publicités à l'avenir. Lorsque
+        nous les introduirons, les partenaires affiliés et les réseaux publicitaires pourront
+        utiliser des témoins ou des technologies similaires pour diffuser du contenu pertinent.
+        La présente politique de confidentialité sera mise à jour en conséquence.
+      </p>
+
+      <h2>Conservation des données</h2>
+      <p>
+        Les données analytiques sont conservées selon les politiques de conservation par défaut
+        de Google Analytics (26 mois) et de Cloudflare Web Analytics (6 mois). Nous ne stockons
+        aucune donnée personnelle sur nos propres serveurs.
+      </p>
+
+      <h2>Vos droits</h2>
+      <p>Vous avez le droit de :</p>
+      <ul>
+        <li>Refuser le suivi Google Analytics en utilisant le module complémentaire mentionné ci-dessus</li>
+        <li>Effacer les témoins et le stockage local dans les paramètres de votre navigateur</li>
+        <li>Demander des informations sur les données que nous détenons (bien que nous ne détenions aucune donnée personnelle identifiable)</li>
+      </ul>
+
+      <h2>Vie privée des enfants</h2>
+      <p>
+        Le Site ne s'adresse pas aux enfants de moins de 13 ans. Nous ne recueillons pas
+        sciemment de renseignements personnels auprès d'enfants. Si vous croyez qu'un enfant
+        nous a fourni des données personnelles, veuillez nous contacter afin que nous puissions
+        prendre les mesures appropriées.
+      </p>
+
+      <h2>Modifications à cette politique</h2>
+      <p>
+        Nous pouvons mettre à jour la présente politique de confidentialité de temps à autre.
+        Les modifications seront publiées sur cette page avec une date de « Dernière mise à jour »
+        actualisée. Nous vous encourageons à consulter cette page périodiquement.
+      </p>
+
+      <h2>Contact</h2>
+      <p>
+        Si vous avez des questions concernant cette politique de confidentialité, n'hésitez pas
+        à nous écrire via notre <a href="/fr/contact/">page de contact</a>.
+      </p>
+    </div>
+  </div>
+</BaseLayout>


### PR DESCRIPTION
## Summary
- Add bilingual **Privacy Policy** pages (`/en/privacy-policy/`, `/fr/politique-de-confidentialite/`)
- Add bilingual **Terms of Service** pages (`/en/terms-of-service/`, `/fr/conditions-dutilisation/`)
- Add **Legal** section to footer with links to both pages (replaces decorative tagline column)
- Add i18n route mapping for seamless EN/FR language switching on legal pages

### Privacy Policy covers:
- Google Analytics & Cloudflare Web Analytics tracking
- Google Fonts third-party requests
- localStorage dark mode preference
- Cookie usage and opt-out options
- Future affiliate links & advertising disclosure
- Data retention policies
- Children's privacy (COPPA)
- Quebec/Canada governing law

### Terms of Service covers:
- Personal, non-commercial use terms
- Intellectual property & copyright
- Recipe disclaimer (nutrition, allergens, cooking times)
- Future affiliate links & advertising disclosure
- Limitation of liability & warranty disclaimer
- Quebec/Canada governing law

## Test plan
- [ ] Visit `/en/privacy-policy/` and `/fr/politique-de-confidentialite/` — verify content renders
- [ ] Visit `/en/terms-of-service/` and `/fr/conditions-dutilisation/` — verify content renders
- [ ] Toggle language on each page — verify correct EN/FR switching
- [ ] Check footer on any page — verify Legal section with both links
- [ ] Test dark mode on all 4 pages
- [ ] Test mobile responsiveness of footer grid layout
- [ ] Verify breadcrumbs display correctly on all 4 pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)