### PR TITLE
feat(recipe): auto-publish recipes from Notion

### DIFF
--- a/.github/workflows/auto-publish-recipe.yml
+++ b/.github/workflows/auto-publish-recipe.yml
@@ -1,0 +1,331 @@
+name: Auto-Publish Recipe
+
+on:
+  schedule:
+    - cron: '0 3 * * 4' # Thursday 3 AM UTC
+  workflow_dispatch: # Manual trigger
+
+concurrency:
+  group: auto-publish-recipe
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      # Step 1: Fetch recipe from public Notion database (no auth needed)
+      # Uses notion-client (unofficial API) to query the publicly shared database.
+      # Note: notion-client depends on Notion's internal /api/v3/ — if it breaks,
+      # fall back to the local notion/ folder exports.
+      - name: Fetch and select recipe from Notion
+        id: select
+        run: node scripts/fetch-notion-recipe.mjs
+
+      # Step 2: Close stale auto-recipe PRs
+      - name: Close stale auto-recipe PRs
+        if: steps.select.outputs.found == 'true'
+        run: |
+          OPEN_PRS=$(gh pr list --label "auto-recipe" --state open --json number --jq '.[].number')
+          for PR in $OPEN_PRS; do
+            gh pr close "$PR" --comment "Superseded by new auto-publish run."
+          done
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      # Step 3: Claude generates the recipe
+      - name: Claude Code Recipe Generation
+        if: steps.select.outputs.found == 'true'
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.PAT_TOKEN }}
+          prompt: |
+            You are running the automated recipe publishing pipeline for Date My Dish.
+
+            ## Input
+            Two JSON files have been pre-fetched from the public Notion database:
+
+            1. **`notion-recipe-selection.json`** — Contains: `pageId`, `recipeNum`, `title`, `mode` ("publish" or "update"), and `existingSlug` (only for updates).
+            2. **`notion-recipe-content.json`** — Contains the full recipe content:
+               - `title`, `recipeNum`, `lastEditedTime`
+               - `cookTime` (text, e.g., "30 minutes"), `prepTime`, `totalTime` — human-readable times from Notion
+               - `difficulty` (lowercased, e.g., "easy", "medium", "hard")
+               - `servings` (number, e.g., 4)
+               - `category` (Notion category, e.g., "Others", "Main", "Appetizers", "Desserts")
+               - `heroImage`: `{ localPath, caption }` — the hero image has already been downloaded to `/tmp/notion-images/`
+               - `blocks`: Array of structured content blocks, each with a `type` field:
+                 - `{ type: "heading", level: 2, text: "..." }`
+                 - `{ type: "paragraph", text: "Markdown text with **bold** and [links](url)..." }`
+                 - `{ type: "list", style: "unordered"|"ordered", items: ["...", "..."] }`
+                 - `{ type: "image", url: "...", localPath: "/tmp/notion-images/...", caption: "..." }`
+                 - `{ type: "callout", icon: "emoji", text: "..." }`
+                 - `{ type: "toggle", text: "..." }`
+                 - `{ type: "divider" }`
+               - `faqs`: Array of `{ question, answer }` objects extracted from the recipe
+
+            Read both files to understand the recipe content and mode.
+            - **publish mode**: Create new EN+FR MDX files and a new published.json entry.
+            - **update mode**: The recipe was already published but has been edited in Notion. The `existingSlug` field contains the current EN slug. Regenerate the EN+FR MDX files in-place (overwrite), keeping the same slugs and `publishDate`, but updating content and `lastSyncedDate` in published.json.
+
+            ## Your Tasks
+
+            ### 1. Optimize images
+            The hero image has already been downloaded to the path in `notion-recipe-content.json` → `heroImage.localPath`.
+
+            **Hero image**: Convert to WebP, resize to max 1200px wide, quality 82:
+            ```
+            convert {heroImage.localPath} -resize '1200x>' -quality 82 src/assets/images/recipes/{slug}.webp
+            ```
+            If the result exceeds 200KB, reduce quality by 5 incrementally until it fits.
+
+            **Step/inline images**: For each image block with a `localPath`, convert to WebP, resize to max 900px wide, quality 80:
+            ```
+            convert {localPath} -resize '900x>' -quality 80 src/assets/images/recipes/{slug}-{descriptor}.webp
+            ```
+            If the result exceeds 150KB, reduce quality by 5 incrementally until it fits.
+            Use descriptive filenames like `{slug}-step-1.webp`, `{slug}-ingredients.webp`, etc.
+
+            ### 2. Generate the EN slug
+            If mode is "update", use the `existingSlug` from the selection JSON.
+            If mode is "publish", derive an SEO-friendly English slug from the title:
+            - Lowercase, replace spaces with hyphens
+            - Remove special characters (colons, apostrophes, parentheses, ampersands)
+            - Keep it concise (3-6 words max)
+            - Examples from existing recipes:
+              - "Vietnamese Pickled Vegetables (Do Chua)" -> `vietnamese-pickled-vegetables`
+              - "Authentic Cacio e Pepe" -> `cacio-e-pepe`
+              - "Bold Spicy Miso Ramen" -> `spicy-miso-ramen`
+
+            ### 3. Generate the FR slug
+            If mode is "update", read the existing EN MDX file to get the current `translationSlug` value.
+            If mode is "publish", create a meaningful French translation of the slug concept:
+            - Examples:
+              - `vietnamese-pickled-vegetables` -> `legumes-marines-vietnamiens`
+              - `cacio-e-pepe` -> `cacio-e-pepe`
+              - `spicy-miso-ramen` -> `ramen-miso-piquant`
+
+            ### 4. Generate EN MDX file
+            Create `src/content/recipes/en/{en-slug}.mdx` with:
+
+            **Frontmatter** (match schema exactly — see `src/content/recipes/en/cacio-e-pepe.mdx` as template):
+            - `title`: Original Notion title or a polished version (in quotes)
+            - `lang`: `en`
+            - `translationSlug`: The FR slug from step 3 (in quotes)
+            - `description`: Max 160 chars, SEO-optimized summary (in quotes)
+            - `author`: `"Victor"`
+            - `publishDate`: Today's date (YYYY-MM-DD). If mode is "update", keep the original publishDate and add `updatedDate` with today's date.
+            - `heroImage`: `"../../../assets/images/recipes/{en-slug}.webp"`
+            - `heroImageAlt`: Descriptive alt text ~125 chars based on the hero image (in quotes)
+            - `prepTime`: Convert from Notion text to ISO 8601 duration matching `/^PT\d+[HM](\d+[MS])?$/`. Examples: "15 minutes" -> "PT15M", "1 hour 30 minutes" -> "PT1H30M", "3 hours" -> "PT3H". Strip qualifiers like "about", "approximately", "plus resting time". For non-numeric values like "overnight", estimate (e.g., "PT8H").
+            - `cookTime`: Same ISO 8601 conversion as prepTime
+            - `totalTime`: Same ISO 8601 conversion as prepTime
+            - `recipeYield`: `"{servings} servings"` format (or more specific unit if appropriate, e.g., "4 steaks")
+            - `difficulty`: Use the lowercase value from JSON (must be "easy", "medium", or "hard")
+            - `recipeCategory`: Map from Notion Category to canonical EN keys. MUST be one of: `appetizer`, `dinner`, `dessert`, `breakfast`, `lunch`, `snack`, `side-dish`, `drink`, `sauce`. Mapping: "Main" -> `["dinner"]`, "Appetizers" -> `["appetizer"]`, "Desserts" -> `["dessert"]`, "Others" or missing -> infer from content.
+            - `recipeCuisine`: Infer from recipe content (e.g., "Italian", "Vietnamese", "Korean", "Japanese", "Mexican", "Thai", "French", "Mediterranean")
+            - `keywords`: 8-12 SEO keywords as array
+            - `tags`: 3-5 topic tags as array (e.g., `["vietnamese", "pickled", "side-dish", "quick"]`)
+            - `ingredientGroups`: Structure from Notion blocks. Look for headings containing "Ingredient" to identify sections. Each group: `{ group: "section name" or "", items: ["ingredient 1", "ingredient 2"] }`. Items from bulleted/unordered lists under ingredient headings.
+            - `instructionGroups`: Structure from Notion blocks. Look for headings containing "Instruction", "Method", "Steps", or "Directions". Each group: `{ group: "section name" or "", steps: [{ text: "step description" }] }`. Steps contain `text` only (NO images in frontmatter steps).
+            - `nutrition`: Approximate nutritional info: `{ calories: "X kcal", fatContent: "Xg", carbohydrateContent: "Xg", proteinContent: "Xg" }`
+            - `occasion`: Array from: `date-night`, `weeknight`, `entertaining`, `comfort`, `celebration`, `quick-meal`. Choose 1-3 that fit.
+            - `impressFactor`: 1-5 rating (how impressive for a date night)
+            - `dateNightTips`: `{ wine: "...", music: "...", platingTip: "..." }` — Generate appropriate suggestions
+            - `faqs`: At least 3 FAQ entries with expanded answers (~2-3 sentences each). Use Notion FAQs if extracted, supplement or generate if fewer than 3.
+
+            **Body**: Write 800-1500 words of SEO-optimized prose:
+            - Start with `import { Picture } from "astro:assets";` and import statements for each optimized image
+            - Image imports use relative paths: `import imgName from "../../../assets/images/recipes/{slug}-{descriptor}.webp";`
+            - Opening paragraph (no heading) — engaging hook related to date night cooking
+            - 5-8 H2 sections covering the recipe's story, techniques, and tips
+            - Include `<Picture>` components for step/inline images throughout the body:
+              ```
+              <Picture
+                src={imgName}
+                alt="Descriptive alt text (~125 chars)"
+                widths={[400, 600, 900]}
+                sizes="(max-width: 896px) 100vw, 896px"
+                formats={["avif", "webp"]}
+                class="my-6 w-full rounded-lg"
+                loading="lazy"
+              />
+              ```
+            - Use the Notion content as an outline but REWRITE the prose — make it more engaging, detailed, and SEO-friendly
+            - Include the "date night" angle throughout (this is a date night cooking blog)
+            - Internal cross-links to existing recipes: `/en/recipes/{slug}/` (trailing slash required)
+            - Check existing recipe slugs: Glob for `src/content/recipes/en/*.mdx` to find linkable recipes
+
+            ### 5. Generate FR MDX file
+            Create `src/content/recipes/fr/{fr-slug}.mdx`:
+            - Translate ALL frontmatter values to Quebec French
+            - `lang`: `fr`
+            - `translationSlug`: The EN slug from step 2 (in quotes)
+            - `heroImage`: Same path as EN (shared image file)
+            - `heroImageAlt`: French translation of alt text
+            - `recipeYield`: `"{servings} portions"` (Quebec French for servings)
+            - `recipeCuisine`: French translation (e.g., "Italienne", "Vietnamienne", "Coréenne")
+            - `keywords`: French SEO keywords
+            - `tags`: French tags
+            - `ingredientGroups`: Fully translated to French (measurements: cuillère à thé/tsp, cuillère à soupe/tbsp, tasses/cups)
+            - `instructionGroups`: Fully translated to French
+            - `nutrition`: Same values (units are universal)
+            - `dateNightTips`: Translated to French
+            - `faqs`: Fully translated to Quebec French
+            - Body: Full Quebec French translation of the EN prose
+            - Quebec French conventions: souper (dinner), déjeuner (breakfast), dîner (lunch), cuillère à soupe (tbsp), tasses (cups), portions (servings)
+            - Cross-links use `/fr/recettes/{slug}/` (French route with trailing slash)
+            - Image imports and `<Picture>` components: same image files, French alt text
+
+            ### 6. Update published.json
+            Read `notion/published.json`:
+
+            **If mode = "publish"** — add a new entry:
+            ```json
+            "{recipe_num}": {
+              "notionTitle": "{original Notion title}",
+              "slug": "{en-slug}",
+              "type": "recipe",
+              "publishedDate": "{today YYYY-MM-DD}",
+              "lastSyncedDate": "{today YYYY-MM-DD}",
+              "status": "published"
+            }
+            ```
+
+            **If mode = "update"** — update only `lastSyncedDate` to today:
+            ```json
+            "{recipe_num}": {
+              ...existing fields unchanged...,
+              "lastSyncedDate": "{today YYYY-MM-DD}"
+            }
+            ```
+
+            ### 7. Validate
+            Run `npm run check` to verify schema compliance.
+            If it fails, read the error messages, fix the issues, and re-run.
+            Common issues to watch for:
+            - ISO 8601 times not matching `/^PT\d+[HM](\d+[MS])?$/`
+            - `description` exceeding 160 characters
+            - Missing required frontmatter fields
+            - Image paths not resolving (ensure images were saved correctly)
+
+            ### 8. Verify EN/FR pair
+            Confirm that:
+            - EN file's `translationSlug` matches the FR file's slug (filename without .mdx)
+            - FR file's `translationSlug` matches the EN file's slug
+            - Both files exist
+
+            ## Restrictions
+            - ONLY create/modify files in: `src/content/recipes/`, `src/assets/images/recipes/`, `notion/published.json`
+            - In **publish** mode: create new files only (except `notion/published.json`)
+            - In **update** mode: overwrite the existing EN+FR MDX files and images for the recipe being updated
+            - Do NOT modify components, layouts, pages, i18n files, or config files
+            - Do NOT modify `package.json`, `astro.config.ts`, `wrangler.jsonc`, or `CLAUDE.md`
+
+            ## Output
+            Provide a summary listing:
+            - Mode (publish or update)
+            - Recipe title and Recipe #
+            - EN slug and FR slug
+            - Recipe category assigned
+            - Cuisine identified
+            - Number of ingredient groups and total ingredients
+            - Number of instruction groups and total steps
+            - Word count of EN prose
+            - Number of FAQs
+            - Image optimization results (original size -> final size for each)
+            - Any issues encountered
+          claude_args: |
+            --model claude-sonnet-4-6
+            --max-turns 30
+            --allowedTools "Edit,Read,Write,Glob,Grep,Bash(convert:*),Bash(node:*),Bash(npm run:*),Bash(ls:*),Bash(cat:*),Bash(wc:*),Bash(du:*),Bash(file:*),Bash(identify:*),Bash(mkdir:*),Bash(which:*),Bash(cp:*)"
+          branch_prefix: "auto-recipe/"
+
+      # Step 4: Check for changes and create PR
+      - name: Check for changes
+        if: steps.select.outputs.found == 'true'
+        id: changes
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Verify build
+        if: steps.changes.outputs.has_changes == 'true'
+        run: npm run check && npm run build
+
+      - name: Create branch and push
+        if: steps.changes.outputs.has_changes == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          BRANCH="auto-recipe/$(date +%Y-%m-%d)-${{ github.run_id }}"
+          echo "BRANCH=$BRANCH" >> $GITHUB_ENV
+          git checkout -b "$BRANCH"
+          git add src/content/recipes/ src/assets/images/recipes/ notion/published.json
+          git commit -m "feat(recipe): auto-publish recipe from Notion
+
+          Generated by Auto-Publish Recipe workflow.
+
+          Co-Authored-By: Claude <noreply@anthropic.com>"
+          git push -u origin "$BRANCH"
+        env:
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+
+      - name: Create PR
+        if: steps.changes.outputs.has_changes == 'true'
+        run: |
+          # Read the selection JSON for PR title context
+          TITLE=$(node -e "const s = require('./notion-recipe-selection.json'); console.log(s.title || 'New recipe')" 2>/dev/null || echo "New recipe")
+
+          gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "Auto-publish: $TITLE" \
+            --body "## Summary
+          - Auto-generated recipe from Notion database
+          - Created by the weekly auto-publish pipeline
+
+          ## Verify
+          - [ ] EN recipe renders correctly
+          - [ ] FR recipe renders correctly
+          - [ ] Images optimized and displaying
+          - [ ] JSON-LD schema valid
+          - [ ] Cross-links working
+          - [ ] All frontmatter fields pass validation
+
+          🤖 Generated with [Claude Code](https://claude.com/claude-code)" \
+            --label "auto-recipe"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      # Step 6: Create issue on failure
+      - name: Create issue on failure
+        if: failure()
+        run: |
+          gh issue create \
+            --title "Auto-publish recipe failed ($(date +%Y-%m-%d))" \
+            --body "The weekly auto-publish recipe workflow failed. [View run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})" \
+            --label "auto-recipe-failure"
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/docs/brainstorms/2026-02-27-auto-publish-notion-recipes-brainstorm.md
+++ b/docs/brainstorms/2026-02-27-auto-publish-notion-recipes-brainstorm.md
@@ -1,0 +1,160 @@
+---
+topic: Auto-Publish Recipes from Notion
+type: feature
+date: 2026-02-27
+status: complete
+related:
+  - docs/brainstorms/2026-02-27-notion-client-public-page-brainstorm.md
+  - docs/brainstorms/2026-02-27-auto-publish-notion-articles-brainstorm.md
+---
+
+# Auto-Publish Recipes from Notion
+
+## What We're Building
+
+A GitHub Actions workflow that automatically publishes recipes from the public Notion database to the Date My Dish blog — mirroring the existing auto-publish article pipeline but adapted for the much richer recipe content schema.
+
+The workflow will:
+1. Run weekly on a different day than articles (articles = Monday)
+2. Fetch the next "Ready to Publish" recipe from the public Notion database via `notion-client`
+3. Download all images from the Notion page (hero + inline/step images)
+4. Have Claude generate complete bilingual EN+FR MDX files with full structured frontmatter
+5. Create a PR for review
+
+## Why This Approach
+
+### Separate Workflow + Script (Approach A)
+
+We chose to create a **separate** `auto-publish-recipe.yml` and `fetch-notion-recipe.mjs` rather than unifying with the article pipeline because:
+
+- **Proven pattern**: The article pipeline works. Mirror it, don't merge.
+- **Different content schemas**: Recipes have 17+ required fields, structured ingredients/instructions, multiple images, cooking times, nutrition — fundamentally different from articles.
+- **Independent debugging**: If the recipe workflow breaks, it doesn't affect article publishing.
+- **YAGNI**: Extracting shared utilities makes sense when there are 3+ content types, not 2.
+
+### Script Extracts, Claude Structures
+
+The Node.js script handles deterministic work (Notion API, image downloads, block-to-JSON conversion). Claude handles semantic work (structuring ingredients into `ingredientGroups`, generating missing fields like `keywords`, `tags`, `dateNightTips`, writing SEO prose).
+
+This matches the article pipeline: script fetches and structures raw data, Claude generates the final MDX.
+
+## Key Decisions
+
+1. **Approach**: Separate workflow + script (mirrors article pipeline)
+2. **Schedule**: Weekly on a different day (e.g., Thursday 3 AM UTC) to spread content
+3. **Images**: Download ALL images from Notion pages (hero + inline/step) and optimize them
+4. **AI generation scope**: Claude generates everything missing from Notion — `recipeCuisine`, `keywords`, `tags`, `occasion`, `impressFactor`, `dateNightTips`, `nutrition`, full SEO prose, and the structured `ingredientGroups`/`instructionGroups` from Notion's block content
+5. **Parsing split**: Script converts Notion blocks to structured JSON (same as articles); Claude interprets the content and builds the recipe frontmatter
+6. **Time conversion**: Notion has human-readable times ("30 minutes"); Claude converts to ISO 8601 (`PT30M`) since it handles edge cases like "3 hours 30 minutes (plus overnight pickling)" better than regex
+7. **Post type filter**: Script filters for `Post Type === "Recipes"` AND `Status === "Ready to Publish"`
+
+## Lessons from Article Pipeline (Must Apply)
+
+These were discovered during the article auto-publish implementation and must be carried into the recipe pipeline:
+
+1. **Two-token CI strategy**: `PAT_TOKEN` for `git push` (bypasses branch protection) and `github.token` for `gh pr create` (has PR GraphQL permissions). Using PAT_TOKEN for PR creation fails with `Resource not accessible by personal access token`. These must be **separate workflow steps** with branch name passed via `$GITHUB_ENV`.
+
+2. **Exclude temp CI artifacts**: `git add -A` will commit `notion-recipe-selection.json` and `notion-recipe-content.json` to the PR branch. Use selective `git add` targeting only `src/content/recipes/`, `src/assets/images/recipes/`, and `notion/published.json` instead.
+
+3. **allowedTools prefix matching**: Claude Code Action's `allowedTools` must use `:*` suffix for prefix matching (e.g., `Bash(convert:*)`, `Bash(npm run:*)`). Without the suffix, only exact command matches are allowed and all Bash commands get denied.
+
+4. **notion-client double-nesting**: The internal API returns data at `.value.value` (double-nested). Must handle both `.value.value` and `.value` patterns for forward-compatibility: `const block = record?.value?.value || record?.value;`
+
+5. **Step images as Astro `image()` imports**: Per `src/content.config.ts`, `instructionGroups.steps[].image` uses Astro's `image()` schema. Claude must save step images as optimized WebP to `src/assets/images/recipes/{slug}-step-{n}.webp` and reference them as relative import paths (`"../../../assets/images/recipes/{slug}-step-{n}.webp"`), not URLs.
+
+6. **published.json `type` field**: Recipe entries must use `"type": "recipe"` (existing article entries use `"type": "article"`) for future filtering between content types.
+
+## Notion Recipe Data Available
+
+### From Database Columns
+| Column | Type | Example |
+|--------|------|---------|
+| Recipe # | number | 3 |
+| Post Title | title | "Vietnamese Pickled Vegetables (Do Chua)" |
+| Category | select | "Others", "Main", "Appetizers", "Desserts" |
+| Status | status | "Ready to Publish" |
+| Post Type | select | "Recipes" |
+| Cook Time | text | "30 minutes", "3 hours 30 minutes" |
+| Prep Time | text | "15 minutes" |
+| Total Time | text | "45 minutes" |
+| Difficulty | select | "Easy", "Medium" |
+| Servings | number | 2, 4, 6 |
+
+### From Page Content (blocks)
+- Ingredients (lists, possibly grouped by section headings)
+- Instructions (numbered steps, possibly with inline images)
+- Hero image and step/process photos
+- Descriptive text, tips, notes
+- Possibly FAQ section
+
+### NOT in Notion (Claude must generate)
+- `recipeCuisine` — inferred from recipe content
+- `keywords` — SEO keywords (8-12)
+- `tags` — topic tags (3-5)
+- `occasion` — date-night, weeknight, etc.
+- `impressFactor` — 1-5 rating
+- `dateNightTips` — wine/music/plating suggestions
+- `nutrition` — approximate nutritional info
+- `description` — max 160 char SEO meta description
+- `heroImageAlt` — descriptive alt text
+- `faqs` — at least 1, ideally 3+
+- MDX body — 800-1500 word SEO blog prose
+
+## Category Mapping
+
+Notion categories need mapping to canonical recipe categories:
+
+| Notion Category | Canonical `recipeCategory` |
+|----------------|---------------------------|
+| Main | `["dinner"]` |
+| Appetizers | `["appetizer"]` |
+| Desserts | `["dessert"]` |
+| Others | Claude infers from content |
+| (missing) | Claude infers from content |
+
+## Architecture Overview
+
+```
+┌──────────────────────────────────────────────────┐
+│  GitHub Actions: auto-publish-recipe.yml          │
+│                                                   │
+│  1. npm ci                                        │
+│  2. node scripts/fetch-notion-recipe.mjs          │
+│     ├── Query public Notion DB (notion-client)    │
+│     ├── Filter: Recipes + Ready to Publish        │
+│     ├── Check notion/published.json               │
+│     ├── Fetch page blocks → structured JSON       │
+│     ├── Download all images to /tmp/              │
+│     └── Output: selection.json + content.json     │
+│  3. Close stale auto-recipe PRs                   │
+│  4. Claude Code Action (sonnet-4-6, agent mode)   │
+│     ├── Read JSON files                           │
+│     ├── Optimize images (hero + step → WebP)      │
+│     ├── Generate EN slug + FR slug                │
+│     ├── Structure ingredients/instructions        │
+│     ├── Generate all missing fields               │
+│     ├── Write EN + FR MDX                         │
+│     ├── Update published.json (type: "recipe")    │
+│     └── npm run check                             │
+│  5. Check for changes (git status --porcelain)    │
+│  6. Verify build (npm run check && npm run build) │
+│  7. Create branch + push (PAT_TOKEN)              │
+│     └── Selective git add (no temp JSON files)    │
+│  8. Create PR (github.token) + label "auto-recipe"│
+│  9. Create issue on failure                       │
+└──────────────────────────────────────────────────┘
+```
+
+## Current State
+
+- 23 recipes in Notion database (Recipe # 1-23)
+- Only 1 is "Ready to Publish": Recipe #3 (Vietnamese Pickled Vegetables)
+- 1 is "Draft": Recipe #23 (Pan-Seared Ribeye)
+- Rest are "In Progress"
+- 17 recipes already manually published on the blog
+
+## Resolved Questions
+
+1. **Which day of the week?** — Different from Monday (articles). Thursday is a good midweek option for content diversity.
+2. **What if no recipes are "Ready to Publish"?** — Same pattern as articles: script sets `found=false`, workflow skips Claude step gracefully.
+3. **Publish vs Update mode?** — Same as articles: if the recipe is already in `published.json` but Notion's `last_edited_time` is newer than `lastSyncedDate`, run in "update" mode (regenerate MDX in-place, keep same slugs and publishDate).

--- a/docs/plans/2026-02-27-feat-auto-publish-notion-recipes-plan.md
+++ b/docs/plans/2026-02-27-feat-auto-publish-notion-recipes-plan.md
@@ -1,0 +1,241 @@
+---
+title: "feat: Auto-Publish Recipes from Notion"
+type: feat
+status: completed
+date: 2026-02-27
+origin: docs/brainstorms/2026-02-27-auto-publish-notion-recipes-brainstorm.md
+---
+
+# feat: Auto-Publish Recipes from Notion
+
+## Overview
+
+A GitHub Actions workflow that automatically publishes recipes from the public Notion database to Date My Dish — mirroring the proven article auto-publish pipeline but adapted for the much richer recipe content schema (17+ required fields, structured ingredients/instructions, multiple images, cooking times, nutrition).
+
+Two deliverables:
+1. **`scripts/fetch-notion-recipe.mjs`** — Node.js script that fetches recipe data from Notion, extracts database columns + page content, downloads images, outputs structured JSON.
+2. **`.github/workflows/auto-publish-recipe.yml`** — GitHub Actions workflow orchestrating the script, Claude Code generation, and PR creation.
+
+## Problem Statement / Motivation
+
+17 recipes are already manually published. The Notion database has 23 total recipes, with Recipe #3 (Vietnamese Pickled Vegetables) ready to publish. Manual publishing requires: creating EN+FR MDX files with 17+ frontmatter fields, optimizing images, writing SEO prose, updating published.json — a 2+ hour process per recipe. Automating this mirrors the article pipeline and enables weekly content cadence.
+
+## Proposed Solution
+
+Mirror the article auto-publish architecture (see brainstorm: `docs/brainstorms/2026-02-27-auto-publish-notion-recipes-brainstorm.md`) with recipe-specific adaptations:
+
+- **Separate workflow + script** — independent from articles, different schedule (Thursday vs Monday)
+- **Script extracts, Claude structures** — script handles Notion API + image downloads; Claude handles semantic structuring (ingredients → `ingredientGroups`, times → ISO 8601, generating missing fields)
+- **Two-token CI strategy** — `PAT_TOKEN` for push, `github.token` for PR creation
+- **Selective git add** — exclude temp JSON artifacts from PR
+
+## Technical Considerations
+
+### Key Design Decisions (from brainstorm)
+
+1. **Step images in MDX body only, NOT in frontmatter** — All 9 existing recipes use `<Picture>` in prose; none use `instructionGroups[].steps[].image`. Follow established pattern to reduce complexity.
+2. **Database columns extracted by script** — Cook Time, Prep Time, Total Time, Difficulty, Servings, Category passed as top-level JSON fields so Claude has structured access.
+3. **No hero image = skip recipe** — `heroImage` is required (`image()`, non-optional). If no hero image found, script sets `found=false` and logs a warning rather than creating an MDX that will fail validation.
+4. **ISO 8601 regex**: Must match `/^PT\d+[HM](\d+[MS])?$/` — Claude strips qualifiers ("about", "plus resting time") and converts only the numeric portion. For truly non-numeric values ("overnight"), Claude estimates (e.g., `PT8H`).
+5. **`recipeYield` format**: `"{n} servings"` (EN) / `"{n} portions"` (FR) by default, with flexibility for specific units (e.g., "4 steaks").
+6. **Difficulty lowercasing**: Script lowercases the Notion value ("Easy" → "easy") before passing to JSON.
+7. **`recipeCategory` canonical keys only**: Must be one of `appetizer`, `dinner`, `dessert`, `breakfast`, `lunch`, `snack`, `side-dish`, `drink`, `sauce`. Claude prompt must include this enum.
+8. **Remove `continue-on-error` on build verification** — Unlike articles, recipe schema is complex enough that build failures should block PR creation.
+9. **`max-turns: 30`** for Claude (vs 25 for articles) — more fields, more images, more structuring work.
+10. **Recursive block traversal (depth 3)** — Handle toggle blocks and nested content in Notion pages.
+
+### Files to Create
+
+| File | Purpose |
+|------|---------|
+| `scripts/fetch-notion-recipe.mjs` | Fetch recipe from Notion, download images, output JSON |
+| `.github/workflows/auto-publish-recipe.yml` | GitHub Actions workflow |
+
+### Files to Modify
+
+| File | Change |
+|------|--------|
+| `notion/published.json` | New entries added by workflow (type: "recipe") |
+
+### Reference Files
+
+| File | Why |
+|------|-----|
+| `scripts/fetch-notion-article.mjs` | Template for the recipe fetch script |
+| `.github/workflows/auto-publish-article.yml` | Template for the workflow YAML |
+| `src/content.config.ts:37-78` | Recipe Zod schema (source of truth) |
+| `src/content/recipes/en/cacio-e-pepe.mdx` | Template for EN recipe MDX |
+| `src/content/recipes/fr/cacio-e-pepe.mdx` | Template for FR recipe MDX |
+
+## Implementation Phases
+
+### Phase 1: Fetch Script (`scripts/fetch-notion-recipe.mjs`)
+
+Fork `scripts/fetch-notion-article.mjs` and adapt for recipes.
+
+- [x] Copy `fetch-notion-article.mjs` → `fetch-notion-recipe.mjs`
+- [x] Change filter: `Post Type === "Recipes"` instead of `"Informative Posts"`
+- [x] Extract additional database columns via `getRowProperty`:
+  - `Cook Time` (text) → `cookTime`
+  - `Prep Time` (text) → `prepTime`
+  - `Total Time` (text) → `totalTime`
+  - `Difficulty` (select) → `difficulty` (lowercased)
+  - `Servings` (number) → `servings`
+  - `Category` (select) → `category`
+- [x] Include extracted columns as top-level fields in `notion-recipe-content.json`
+- [x] Add hero image validation: if no images found in page blocks, set `found=false` and exit gracefully
+- [x] Add recursive block traversal (depth-limited to 3) for toggle blocks and nested content
+- [x] Change output filenames: `notion-recipe-selection.json` and `notion-recipe-content.json`
+- [x] Update `SELECTION_FILE` and `CONTENT_FILE` constants
+- [x] Update console log messages ("article" → "recipe")
+- [ ] Test locally: `node scripts/fetch-notion-recipe.mjs`
+
+**selection.json output format:**
+```json
+{
+  "pageId": "...",
+  "recipeNum": 3,
+  "title": "Vietnamese Pickled Vegetables (Do Chua)",
+  "mode": "publish",
+  "existingSlug": null
+}
+```
+
+**content.json output format:**
+```json
+{
+  "pageId": "...",
+  "title": "Vietnamese Pickled Vegetables (Do Chua)",
+  "recipeNum": 3,
+  "lastEditedTime": "2026-...",
+  "cookTime": "30 minutes",
+  "prepTime": "15 minutes",
+  "totalTime": "45 minutes",
+  "difficulty": "easy",
+  "servings": 4,
+  "category": "Others",
+  "heroImage": { "localPath": "/tmp/notion-images/hero.jpg", "caption": "..." },
+  "blocks": [ ... ],
+  "faqs": [ ... ]
+}
+```
+
+### Phase 2: Workflow YAML (`.github/workflows/auto-publish-recipe.yml`)
+
+Fork `auto-publish-article.yml` and adapt for recipes.
+
+- [x] Create workflow file with recipe-specific settings:
+  - Name: `Auto-Publish Recipe`
+  - Cron: `0 3 * * 4` (Thursday 3 AM UTC)
+  - Concurrency group: `auto-publish-recipe`
+  - Permissions: `contents: write`, `pull-requests: write`, `issues: write`, `id-token: write`
+- [x] Step 1: Checkout, setup Node 20, npm ci
+- [x] Step 2: Run `node scripts/fetch-notion-recipe.mjs` with `id: select`
+- [x] Step 3: Close stale PRs with label `auto-recipe`
+- [x] Step 4: Claude Code Action with recipe-specific prompt (see Phase 3)
+  - Model: `claude-sonnet-4-6`
+  - Max turns: 30
+  - Branch prefix: `auto-recipe/`
+  - allowedTools: `"Edit,Read,Write,Glob,Grep,Bash(convert:*),Bash(node:*),Bash(npm run:*),Bash(ls:*),Bash(cat:*),Bash(wc:*),Bash(du:*),Bash(file:*),Bash(identify:*),Bash(mkdir:*),Bash(which:*),Bash(cp:*)"`
+- [x] Step 5: Check for changes (`git status --porcelain`)
+- [x] Step 6: Verify build (`npm run check && npm run build`) — NO `continue-on-error`
+- [x] Step 7: Create branch and push (PAT_TOKEN)
+  - Branch: `auto-recipe/$(date +%Y-%m-%d)-${{ github.run_id }}`
+  - **Selective git add**: `git add src/content/recipes/ src/assets/images/recipes/ notion/published.json`
+  - Commit: `feat(recipe): auto-publish recipe from Notion`
+- [x] Step 8: Create PR (github.token)
+  - Label: `auto-recipe`
+  - Title: `Auto-publish: {recipe title}`
+- [x] Step 9: Create issue on failure with label `auto-recipe-failure`
+
+### Phase 3: Claude Prompt (embedded in workflow YAML)
+
+Write the detailed Claude prompt for recipe generation. Must cover:
+
+- [x] Read both JSON files (`notion-recipe-selection.json` + `notion-recipe-content.json`)
+- [x] **Image optimization**:
+  - Hero: `convert {path} -resize '1200x>' -quality 82 src/assets/images/recipes/{slug}.webp` (< 200KB)
+  - Step/inline images: `convert {path} -resize '900x>' -quality 80 src/assets/images/recipes/{slug}-{descriptor}.webp` (< 150KB)
+  - Reduce quality incrementally if over size limit
+- [x] **Slug generation**:
+  - Publish mode: derive SEO-friendly EN slug (3-6 words, lowercase, hyphens)
+  - Update mode: use `existingSlug` from selection JSON
+  - FR slug: meaningful Quebec French translation
+- [x] **EN MDX frontmatter** — all 17+ fields with exact format specs:
+  - Template reference: `src/content/recipes/en/cacio-e-pepe.mdx`
+  - `prepTime`/`cookTime`/`totalTime`: Convert from Notion text → ISO 8601 matching `/^PT\d+[HM](\d+[MS])?$/`
+  - `recipeYield`: `"{servings} servings"` (or more specific unit)
+  - `difficulty`: Use lowercase value from JSON
+  - `recipeCategory`: Map from Notion Category → canonical EN keys (`appetizer`, `dinner`, `dessert`, `breakfast`, `lunch`, `snack`, `side-dish`, `drink`, `sauce`). If "Others" or missing, infer from content.
+  - `recipeCuisine`: Infer from content (examples: "Italian", "Vietnamese", "Mediterranean")
+  - `ingredientGroups`: Structure from Notion blocks. Look for headings containing "Ingredient" to identify sections. Group items under sub-headings.
+  - `instructionGroups`: Structure from Notion blocks. Look for headings containing "Instruction", "Method", "Steps", or "Directions". Steps contain `text` only (no images in frontmatter).
+  - `keywords`: 8-12 SEO keywords
+  - `tags`: 3-5 topic tags
+  - `nutrition`: Approximate nutritional info
+  - `occasion`: From `date-night`, `weeknight`, `entertaining`, `comfort`, `celebration`, `quick-meal`
+  - `impressFactor`: 1-5 rating
+  - `dateNightTips`: `{ wine?, music?, platingTip? }`
+  - `description`: Max 160 chars, SEO-optimized
+  - `heroImageAlt`: Descriptive ~125 chars
+  - `faqs`: Min 1 (ideally 3+). Use Notion FAQs if extracted, otherwise generate.
+- [x] **EN MDX body**: 800-1500 words SEO prose with `<Picture>` components, 5-8 H2 sections, internal cross-links `/en/recipes/{slug}/`
+- [x] **FR MDX**: Full Quebec French translation. `lang: fr`, `translationSlug` → EN slug, French keywords/tags/faqs, cross-links `/fr/recettes/{slug}/`
+- [x] **Update mode differences**: Keep original `publishDate`, add `updatedDate`, read existing EN MDX for FR slug via `translationSlug`
+- [x] **published.json update**: Entry with `"type": "recipe"`, `publishedDate`, `lastSyncedDate`
+- [x] **Validation**: Run `npm run check`, fix issues if fails
+- [x] **Restrictions**: Only modify `src/content/recipes/`, `src/assets/images/recipes/`, `notion/published.json`
+
+### Phase 4: Test and Validate
+
+- [x] Create `auto-recipe` label in GitHub repository
+- [ ] Test fetch script locally: `node scripts/fetch-notion-recipe.mjs`
+- [ ] Trigger workflow manually via `workflow_dispatch`
+- [ ] Verify PR content:
+  - All frontmatter fields pass Zod validation (`npm run check`)
+  - ISO 8601 times match the regex
+  - EN/FR `translationSlug` cross-references correct
+  - Images optimized and correctly referenced
+  - Build succeeds
+  - No temp JSON files in PR
+- [ ] If first recipe works, close auto-recipe-failure issue #29 if still open
+
+## Acceptance Criteria
+
+- [ ] `scripts/fetch-notion-recipe.mjs` fetches recipe data from Notion, extracts all database columns, downloads images, outputs structured JSON
+- [ ] Script filters for `Post Type === "Recipes"` AND `Status === "Ready to Publish"`
+- [ ] Script skips recipes with no hero image (sets `found=false`)
+- [ ] Script handles publish and update modes correctly
+- [ ] Workflow runs on Thursday 3 AM UTC cron and manual trigger
+- [ ] Claude generates valid EN+FR MDX recipe pairs with all required frontmatter fields
+- [ ] Images optimized (hero < 200KB, step < 150KB) and saved as WebP
+- [ ] `published.json` updated with `"type": "recipe"` entry
+- [ ] PR created with `auto-recipe` label, no temp JSON artifacts
+- [ ] Build passes (`npm run check && npm run build`)
+- [ ] Failure creates GitHub issue with `auto-recipe-failure` label
+
+## Dependencies & Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| Notion API structure changes (`.value.value` nesting) | Defensive coding: `record?.value?.value \|\| record?.value` |
+| Recipe schema complexity causes Claude errors | 30 max turns, detailed prompt with exact format specs, `npm run check` validation loop |
+| Notion image URLs expire before download | Script downloads eagerly in step 2, before Claude runs |
+| `published.json` merge conflict (article + recipe PRs) | Different schedule days (Mon vs Thu); rare edge case for manual triggers |
+| Recipe has unusual Notion structure (columns, deep nesting) | Recursive block traversal (depth 3), Claude interprets remaining ambiguity |
+
+## Sources & References
+
+### Origin
+
+- **Brainstorm document:** [docs/brainstorms/2026-02-27-auto-publish-notion-recipes-brainstorm.md](docs/brainstorms/2026-02-27-auto-publish-notion-recipes-brainstorm.md) — Key decisions: separate workflow, script-extracts-Claude-structures split, Thursday schedule, step images in prose only
+
+### Internal References
+
+- Article fetch script template: `scripts/fetch-notion-article.mjs`
+- Article workflow template: `.github/workflows/auto-publish-article.yml`
+- Recipe Zod schema: `src/content.config.ts:37-78`
+- Recipe MDX template: `src/content/recipes/en/cacio-e-pepe.mdx`
+- Published tracking: `notion/published.json`
+- Image guidelines: CLAUDE.md (hero < 200KB, step < 150KB)
+- CI lessons learned: brainstorm "Lessons from Article Pipeline" section

--- a/scripts/fetch-notion-recipe.mjs
+++ b/scripts/fetch-notion-recipe.mjs
@@ -1,0 +1,593 @@
+// scripts/fetch-notion-recipe.mjs
+// Fetches the next recipe to publish from a public Notion database using
+// notion-client (unofficial API, no auth needed for public pages).
+//
+// Outputs:
+//   - notion-recipe-selection.json  (recipe metadata + mode)
+//   - notion-recipe-content.json    (structured content blocks + FAQs + images + DB columns)
+//   - $GITHUB_OUTPUT                (found, mode, recipe_num)
+//
+// Usage:
+//   node scripts/fetch-notion-recipe.mjs
+
+import { NotionAPI } from "notion-client";
+import {
+  readFileSync,
+  writeFileSync,
+  existsSync,
+  mkdirSync,
+  appendFileSync,
+} from "fs";
+import { join } from "path";
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+const DATABASE_PAGE_ID = "9ce95183503543d68450194d1010824b";
+const PUBLISHED_JSON = "notion/published.json";
+const IMAGE_DIR = "/tmp/notion-images";
+const SELECTION_FILE = "notion-recipe-selection.json";
+const CONTENT_FILE = "notion-recipe-content.json";
+const MAX_RETRIES = 3;
+const RETRY_BASE_MS = 1000;
+const MAX_BLOCK_DEPTH = 3;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function sleep(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function withRetry(fn, label) {
+  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      if (attempt === MAX_RETRIES) {
+        console.error(`[ERROR] ${label} failed after ${MAX_RETRIES} attempts`);
+        throw err;
+      }
+      const delay = RETRY_BASE_MS * Math.pow(2, attempt - 1);
+      console.log(
+        `[WARN] ${label} attempt ${attempt} failed: ${err.message}. Retrying in ${delay}ms...`
+      );
+      await sleep(delay);
+    }
+  }
+}
+
+function writeGitHubOutput(key, value) {
+  const outputFile = process.env.GITHUB_OUTPUT;
+  if (outputFile) {
+    appendFileSync(outputFile, `${key}=${value}\n`);
+  }
+  console.log(`  ${key}=${value}`);
+}
+
+function readPublishedJson() {
+  if (!existsSync(PUBLISHED_JSON)) return { version: 1, entries: {} };
+  return JSON.parse(readFileSync(PUBLISHED_JSON, "utf-8"));
+}
+
+// ---------------------------------------------------------------------------
+// Schema-based property extraction for notion-client's internal API
+//
+// The internal API returns data at recordMap.collection[id].value.value and
+// recordMap.block[id].value.value (double-nested). Property IDs are random
+// 4-char keys (e.g., "]?xo") mapped via the collection schema.
+// ---------------------------------------------------------------------------
+function buildSchemaLookup(schema) {
+  const lookup = {};
+  for (const [propId, def] of Object.entries(schema)) {
+    lookup[def.name] = propId;
+  }
+  return lookup;
+}
+
+function getRowProperty(row, propName, schemaLookup) {
+  if (propName === "title") {
+    return row.properties?.title?.[0]?.[0] || "";
+  }
+  const propId = schemaLookup[propName];
+  if (!propId) return "";
+  return row.properties?.[propId]?.[0]?.[0] || "";
+}
+
+// ---------------------------------------------------------------------------
+// Notion block → structured JSON conversion
+// ---------------------------------------------------------------------------
+function decorationToMarkdown(decorations) {
+  if (!decorations) return "";
+  return decorations
+    .map((dec) => {
+      const text = dec[0];
+      const annotations = dec[1] || [];
+      let result = text;
+      for (const ann of annotations) {
+        if (ann[0] === "b") result = `**${result}**`;
+        if (ann[0] === "i") result = `*${result}*`;
+        if (ann[0] === "c") result = "`" + result + "`";
+        if (ann[0] === "a") result = `[${result}](${ann[1]})`;
+      }
+      return result;
+    })
+    .join("");
+}
+
+function blockToStructured(block) {
+  const type = block.type;
+  const props = block.properties || {};
+  const titleDec = props.title;
+  const text = titleDec ? decorationToMarkdown(titleDec) : "";
+
+  switch (type) {
+    case "text":
+      return text ? { type: "paragraph", text } : null;
+    case "header":
+      return { type: "heading", level: 1, text };
+    case "sub_header":
+      return { type: "heading", level: 2, text };
+    case "sub_sub_header":
+      return { type: "heading", level: 3, text };
+    case "bulleted_list":
+      return { type: "list_item", style: "unordered", text };
+    case "numbered_list":
+      return { type: "list_item", style: "ordered", text };
+    case "image": {
+      const source =
+        block.format?.display_source ||
+        (props.source && props.source[0]?.[0]) ||
+        null;
+      const caption = props.caption
+        ? decorationToMarkdown(props.caption)
+        : null;
+      return { type: "image", url: source, caption };
+    }
+    case "callout": {
+      const icon = block.format?.page_icon || "";
+      return { type: "callout", icon, text };
+    }
+    case "quote":
+      return { type: "quote", text };
+    case "divider":
+      return { type: "divider" };
+    case "to_do":
+      return { type: "paragraph", text: `- ${text}` };
+    case "toggle":
+      return { type: "toggle", text };
+    default:
+      if (text) return { type: "paragraph", text };
+      return null;
+  }
+}
+
+// Group consecutive list_item blocks into list blocks
+function groupListItems(blocks) {
+  const result = [];
+  let currentList = null;
+
+  for (const block of blocks) {
+    if (block && block.type === "list_item") {
+      if (currentList && currentList.style === block.style) {
+        currentList.items.push(block.text);
+      } else {
+        if (currentList) result.push(currentList);
+        currentList = {
+          type: "list",
+          style: block.style,
+          items: [block.text],
+        };
+      }
+    } else {
+      if (currentList) {
+        result.push(currentList);
+        currentList = null;
+      }
+      if (block) result.push(block);
+    }
+  }
+  if (currentList) result.push(currentList);
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Recursive block traversal (depth-limited)
+// ---------------------------------------------------------------------------
+function traverseBlocks(blockMap, childIds, signedUrls, depth = 0) {
+  const results = [];
+  if (depth >= MAX_BLOCK_DEPTH || !childIds) return results;
+
+  for (const childId of childIds) {
+    const childRecord = blockMap[childId];
+    const child = childRecord?.value?.value || childRecord?.value;
+    if (!child) continue;
+
+    const structured = blockToStructured(child);
+    if (structured) {
+      if (structured.type === "image" && structured.url) {
+        const signedUrl = signedUrls?.[childId] || structured.url;
+        structured.url = signedUrl;
+      }
+      results.push(structured);
+    }
+
+    // Recurse into nested children (toggle content, callout children, etc.)
+    if (child.content) {
+      const nested = traverseBlocks(
+        blockMap,
+        child.content,
+        signedUrls,
+        depth + 1
+      );
+      results.push(...nested);
+    }
+  }
+
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// FAQ extraction
+// ---------------------------------------------------------------------------
+function extractFaqs(blocks) {
+  const faqStart = blocks.findIndex(
+    (b) => b.type === "heading" && /faq|frequently asked/i.test(b.text)
+  );
+
+  if (faqStart === -1) return [];
+
+  const faqBlocks = blocks.slice(faqStart + 1);
+  const faqs = [];
+  let currentQ = null;
+  let currentA = [];
+
+  for (const block of faqBlocks) {
+    if (block.type === "heading") break;
+    const text = block.text || (block.items ? block.items.join(", ") : "");
+
+    const qMatch =
+      text.match(/^\*\*Q:\s*(.+?)\*\*$/) || text.match(/^Q:\s*(.+)/);
+    if (qMatch) {
+      if (currentQ) {
+        faqs.push({ question: currentQ, answer: currentA.join(" ").trim() });
+      }
+      currentQ = qMatch[1].trim();
+      currentA = [];
+    } else if (currentQ && text) {
+      currentA.push(text);
+    }
+  }
+  if (currentQ) {
+    faqs.push({ question: currentQ, answer: currentA.join(" ").trim() });
+  }
+
+  return faqs;
+}
+
+// ---------------------------------------------------------------------------
+// Image download
+// ---------------------------------------------------------------------------
+async function downloadImage(url, filename) {
+  if (!url) return null;
+  mkdirSync(IMAGE_DIR, { recursive: true });
+  const outPath = join(IMAGE_DIR, filename);
+
+  try {
+    const res = await fetch(url);
+    if (!res.ok) {
+      console.log(`[WARN] Failed to download image: ${res.status} ${url}`);
+      return null;
+    }
+    const buffer = Buffer.from(await res.arrayBuffer());
+    writeFileSync(outPath, buffer);
+    console.log(`  Downloaded image: ${outPath} (${buffer.length} bytes)`);
+    return outPath;
+  } catch (err) {
+    console.log(`[WARN] Image download error: ${err.message}`);
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+async function main() {
+  console.log("=== Fetch Notion Recipe ===\n");
+
+  const api = new NotionAPI();
+
+  // Step 1: Fetch the database page to discover collection + view IDs
+  console.log("Step 1: Fetching database page...");
+  const recordMap = await withRetry(
+    () => api.getPage(DATABASE_PAGE_ID, { signFileUrls: false }),
+    "getPage(database)"
+  );
+
+  // Extract collection ID
+  const collectionIds = Object.keys(recordMap.collection || {});
+  if (collectionIds.length === 0) {
+    console.error(
+      "[ERROR] No collection found. Is the Notion page still public?"
+    );
+    process.exit(1);
+  }
+  const collectionId = collectionIds[0];
+
+  // Get the first collection view ID
+  const viewIds = Object.keys(recordMap.collection_view || {});
+  if (viewIds.length === 0) {
+    console.error("[ERROR] No collection views found.");
+    process.exit(1);
+  }
+  const viewId = viewIds[0];
+
+  console.log(`  Collection ID: ${collectionId}`);
+  console.log(`  View ID: ${viewId}`);
+
+  // Step 2: Fetch full collection data with rows
+  console.log("\nStep 2: Fetching collection data...");
+  const collData = await withRetry(
+    () => api.getCollectionData(collectionId, viewId),
+    "getCollectionData"
+  );
+
+  // Extract schema from the double-nested structure: .value.value
+  const collRecord = collData.recordMap?.collection?.[collectionId];
+  const collValue = collRecord?.value?.value || collRecord?.value;
+  const schema = collValue?.schema;
+
+  if (!schema) {
+    console.error(
+      "[ERROR] Could not extract collection schema. The internal API structure may have changed."
+    );
+    process.exit(1);
+  }
+
+  const schemaLookup = buildSchemaLookup(schema);
+  const schemaNames = Object.values(schema).map((s) => s.name);
+  console.log(`  Schema properties: ${schemaNames.join(", ")}`);
+
+  // Verify required properties
+  const required = ["Status", "Post Type", "Recipe #"];
+  for (const req of required) {
+    if (!schemaLookup[req]) {
+      console.error(
+        `[ERROR] Missing property "${req}" in schema. Available: ${schemaNames.join(", ")}`
+      );
+      process.exit(1);
+    }
+  }
+
+  // Get row block IDs
+  const blockIds =
+    collData.result?.reducerResults?.collection_group_results?.blockIds || [];
+  const blockMap = collData.recordMap?.block || {};
+
+  console.log(`  Found ${blockIds.length} rows\n`);
+
+  // Step 3: Parse rows and extract properties
+  console.log("Step 3: Parsing collection rows...");
+  const rows = [];
+  for (const blockId of blockIds) {
+    // Internal API: block data is at .value.value (double-nested)
+    const blockRecord = blockMap[blockId];
+    const block = blockRecord?.value?.value || blockRecord?.value;
+    if (!block || block.type !== "page") continue;
+
+    const status = getRowProperty(block, "Status", schemaLookup);
+    const postType = getRowProperty(block, "Post Type", schemaLookup);
+    const recipeNumRaw = getRowProperty(block, "Recipe #", schemaLookup);
+    const title =
+      getRowProperty(block, "Post Title", schemaLookup) ||
+      block.properties?.title?.[0]?.[0] ||
+      "";
+    const lastEdited = block.last_edited_time;
+
+    // Extract recipe-specific database columns
+    const cookTime = getRowProperty(block, "Cook Time", schemaLookup);
+    const prepTime = getRowProperty(block, "Prep Time", schemaLookup);
+    const totalTime = getRowProperty(block, "Total Time", schemaLookup);
+    const difficultyRaw = getRowProperty(block, "Difficulty", schemaLookup);
+    const servingsRaw = getRowProperty(block, "Servings", schemaLookup);
+    const category = getRowProperty(block, "Category", schemaLookup);
+
+    const recipeNum = parseInt(recipeNumRaw, 10);
+    if (isNaN(recipeNum) || recipeNum === 0) continue;
+
+    rows.push({
+      pageId: blockId,
+      recipeNum,
+      title: String(title).trim(),
+      status: String(status).trim(),
+      postType: String(postType).trim(),
+      lastEditedTime: lastEdited,
+      cookTime: String(cookTime).trim(),
+      prepTime: String(prepTime).trim(),
+      totalTime: String(totalTime).trim(),
+      difficulty: String(difficultyRaw).trim().toLowerCase(),
+      servings: parseInt(servingsRaw, 10) || null,
+      category: String(category).trim(),
+    });
+  }
+
+  console.log(`  Parsed ${rows.length} valid rows\n`);
+
+  // Step 4: Filter for Ready to Publish + Recipes
+  console.log("Step 4: Filtering recipes...");
+  const readyRecipes = rows.filter(
+    (r) => r.status === "Ready to Publish" && r.postType === "Recipes"
+  );
+  console.log(
+    `  ${readyRecipes.length} recipes with "Ready to Publish" + "Recipes"\n`
+  );
+
+  // Step 5: Cross-reference published.json
+  console.log("Step 5: Cross-referencing published.json...");
+  const published = readPublishedJson();
+
+  const unpublished = readyRecipes
+    .filter((a) => !published.entries[String(a.recipeNum)])
+    .sort((a, b) => a.recipeNum - b.recipeNum);
+
+  console.log(`  ${unpublished.length} unpublished recipes`);
+
+  let selected = null;
+  let mode = "publish";
+
+  if (unpublished.length > 0) {
+    selected = unpublished[0];
+    mode = "publish";
+    console.log(
+      `  Selected for publish: #${selected.recipeNum} - ${selected.title}\n`
+    );
+  } else {
+    // Check for stale recipes (edited since last sync)
+    console.log("  No unpublished recipes. Checking for stale recipes...");
+    const stale = readyRecipes
+      .filter((a) => {
+        const entry = published.entries[String(a.recipeNum)];
+        if (!entry) return false;
+        const syncDate = new Date(entry.lastSyncedDate + "T23:59:59Z");
+        const editDate = new Date(a.lastEditedTime);
+        return editDate > syncDate;
+      })
+      .sort((a, b) => a.recipeNum - b.recipeNum);
+
+    console.log(`  ${stale.length} stale recipes`);
+
+    if (stale.length === 0) {
+      console.log("\nNo new or updated recipes found. Exiting.");
+      writeGitHubOutput("found", "false");
+      process.exit(0);
+    }
+
+    selected = stale[0];
+    mode = "update";
+    console.log(
+      `  Selected for update: #${selected.recipeNum} - ${selected.title}\n`
+    );
+  }
+
+  // Step 6: Fetch the selected recipe's page blocks
+  console.log("Step 6: Fetching recipe page blocks...");
+  const pageRecordMap = await withRetry(
+    () => api.getPage(selected.pageId, { signFileUrls: true }),
+    "getPage(recipe)"
+  );
+
+  // Walk the block tree with recursive traversal (depth-limited to 3)
+  const pageBlockRecord = pageRecordMap.block[selected.pageId];
+  const pageBlock = pageBlockRecord?.value?.value || pageBlockRecord?.value;
+  if (!pageBlock) {
+    console.error("[ERROR] Could not find page block for selected recipe.");
+    process.exit(1);
+  }
+
+  const childIds = pageBlock.content || [];
+  const rawBlocks = traverseBlocks(
+    pageRecordMap.block,
+    childIds,
+    pageRecordMap.signed_urls,
+    0
+  );
+
+  const blocks = groupListItems(rawBlocks);
+  const faqs = extractFaqs(blocks);
+
+  const imageCount = blocks.filter((b) => b.type === "image").length;
+  console.log(`  ${blocks.length} content blocks`);
+  console.log(`  ${faqs.length} FAQs extracted`);
+  console.log(`  ${imageCount} images found\n`);
+
+  // Step 7: Download images
+  console.log("Step 7: Downloading images...");
+  let heroImage = null;
+  let imgIndex = 0;
+
+  for (const block of blocks) {
+    if (block.type === "image" && block.url) {
+      imgIndex++;
+      const ext = block.url.match(/\.(png|jpg|jpeg|webp|gif)/i)?.[1] || "png";
+      const isHero = heroImage === null;
+      const filename = isHero ? `hero.${ext}` : `img-${imgIndex}.${ext}`;
+      const localPath = await downloadImage(block.url, filename);
+
+      if (localPath) {
+        block.localPath = localPath;
+        if (isHero) {
+          heroImage = { localPath, caption: block.caption };
+        }
+      }
+    }
+  }
+
+  // Hero image validation: required for recipes
+  if (!heroImage) {
+    console.log(
+      "\n  [WARN] No hero image found in recipe page. Skipping this recipe."
+    );
+    writeGitHubOutput("found", "false");
+    process.exit(0);
+  }
+
+  // Step 8: Write output files
+  console.log("\nStep 8: Writing output files...");
+
+  const existingSlug =
+    mode === "update"
+      ? published.entries[String(selected.recipeNum)]?.slug || null
+      : null;
+
+  const selectionJson = {
+    pageId: selected.pageId,
+    recipeNum: selected.recipeNum,
+    title: selected.title,
+    mode,
+    existingSlug,
+  };
+
+  const contentJson = {
+    pageId: selected.pageId,
+    title: selected.title,
+    recipeNum: selected.recipeNum,
+    lastEditedTime: new Date(selected.lastEditedTime).toISOString(),
+    cookTime: selected.cookTime,
+    prepTime: selected.prepTime,
+    totalTime: selected.totalTime,
+    difficulty: selected.difficulty,
+    servings: selected.servings,
+    category: selected.category,
+    heroImage,
+    blocks,
+    faqs,
+  };
+
+  writeFileSync(SELECTION_FILE, JSON.stringify(selectionJson, null, 2) + "\n");
+  writeFileSync(CONTENT_FILE, JSON.stringify(contentJson, null, 2) + "\n");
+
+  console.log(`  ${SELECTION_FILE} written`);
+  console.log(`  ${CONTENT_FILE} written`);
+
+  // Validate output
+  if (!selectionJson.title || blocks.length === 0) {
+    console.error("[ERROR] Output validation failed: empty title or blocks.");
+    process.exit(1);
+  }
+
+  // Step 9: Write GitHub Actions output
+  console.log("\nStep 9: Writing GITHUB_OUTPUT...");
+  writeGitHubOutput("found", "true");
+  writeGitHubOutput("mode", mode);
+  writeGitHubOutput("recipe_num", String(selected.recipeNum));
+
+  console.log(
+    `\n=== Done! Mode: ${mode} | #${selected.recipeNum} - ${selected.title} ===`
+  );
+}
+
+main().catch((err) => {
+  console.error(`\n[FATAL] ${err.message}`);
+  if (err.stack) console.error(err.stack);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Adds `scripts/fetch-notion-recipe.mjs` — Node.js script that fetches recipe data from the public Notion database, extracts database columns (cook/prep/total time, difficulty, servings, category), downloads images, and outputs structured JSON
- Adds `.github/workflows/auto-publish-recipe.yml` — GitHub Actions workflow running every Thursday 3 AM UTC that orchestrates the fetch script, Claude Code generation, and PR creation
- Mirrors the proven article auto-publish pipeline with recipe-specific adaptations

## Key Differences from Article Pipeline
- **6 additional database columns** extracted: Cook Time, Prep Time, Total Time, Difficulty, Servings, Category
- **Recursive block traversal** (depth-limited to 3) for toggle blocks and nested Notion content
- **Hero image validation** — skips recipe if no hero image found (required field)
- **Comprehensive Claude prompt** covering all 17+ recipe frontmatter fields (ingredients, instructions, ISO 8601 times, nutrition, date night tips, etc.)
- **No `continue-on-error`** on build verification (recipe schema complexity warrants blocking on failure)
- **Selective `git add`** to exclude temp JSON artifacts from PRs
- **`max-turns: 30`** (vs 25 for articles) due to more complex structuring work

## Files
| File | Purpose |
|------|---------|
| `scripts/fetch-notion-recipe.mjs` | Fetch recipe from Notion, download images, output JSON |
| `.github/workflows/auto-publish-recipe.yml` | GitHub Actions workflow with Claude prompt |
| `docs/plans/...` | Implementation plan |
| `docs/brainstorms/...` | Brainstorm document |

## Test Plan
- [ ] Trigger workflow manually via `workflow_dispatch` after merge
- [ ] Verify fetch script finds Recipe #3 (Vietnamese Pickled Vegetables) as "Ready to Publish"
- [ ] Verify Claude generates valid EN+FR MDX with all required frontmatter
- [ ] Verify `npm run check` passes on generated content
- [ ] Verify selective git add excludes temp JSON files from PR
- [ ] Verify `auto-recipe` label applied to generated PR

## Post-Deploy Monitoring & Validation
- **What to monitor**: GitHub Actions workflow runs (Thursday 3 AM UTC)
- **Validation checks**: Check the generated PR for schema compliance, image optimization, EN/FR pair integrity
- **Expected healthy behavior**: Weekly PR created with valid recipe content
- **Failure signal**: `auto-recipe-failure` issue created automatically on workflow failure
- **Validation window**: First Thursday after merge
- **Owner**: Victor

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)