### PR TITLE
fix(ci): add bot_name/bot_id to claude-code-action for scheduled workflows

### DIFF
--- a/.github/workflows/auto-publish-article.yml
+++ b/.github/workflows/auto-publish-article.yml
@@ -57,6 +57,8 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.PAT_TOKEN }}
+          bot_name: "github-actions[bot]"
+          bot_id: "41898282"
           prompt: |
             You are running the automated article publishing pipeline for Date My Dish.
 

--- a/.github/workflows/auto-publish-recipe.yml
+++ b/.github/workflows/auto-publish-recipe.yml
@@ -57,6 +57,8 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.PAT_TOKEN }}
+          bot_name: "github-actions[bot]"
+          bot_id: "41898282"
           prompt: |
             You are running the automated recipe publishing pipeline for Date My Dish.
 


### PR DESCRIPTION
## Summary
- Auto-publish workflows (recipe + article) were failing with a 404 on `GET /users/github-actions` because `claude-code-action` in agent/automation mode tries to look up the authenticated user
- Adding `bot_name` and `bot_id` inputs skips this API call entirely

Fixes #55

## Test plan
- [ ] Re-run the auto-publish recipe workflow manually via `workflow_dispatch`
- [ ] Verify the Claude Code action step no longer fails with 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)