### PR TITLE
fix(recipe): match hero section width with content below

### DIFF
--- a/src/pages/en/recipes/[...slug].astro
+++ b/src/pages/en/recipes/[...slug].astro
@@ -93,7 +93,7 @@ const difficultyColors = {
 
   <article class="mx-auto max-w-content px-4 py-8" data-pagefind-body data-pagefind-filter={`lang:${locale}`}>
     <!-- Full-width zone: Breadcrumbs + Hero + Meta -->
-    <div class="mx-auto max-w-prose">
+    <div class="mx-auto max-w-prose lg:max-w-none">
       <Breadcrumbs
         locale={locale}
         items={[

--- a/src/pages/fr/recettes/[...slug].astro
+++ b/src/pages/fr/recettes/[...slug].astro
@@ -93,7 +93,7 @@ const difficultyColors = {
 
   <article class="mx-auto max-w-content px-4 py-8" data-pagefind-body data-pagefind-filter={`lang:${locale}`}>
     <!-- Full-width zone: Breadcrumbs + Hero + Meta -->
-    <div class="mx-auto max-w-prose">
+    <div class="mx-auto max-w-prose lg:max-w-none">
       <Breadcrumbs
         locale={locale}
         items={[


### PR DESCRIPTION
## Summary
- Adds `lg:max-w-none` to the recipe hero section wrapper (breadcrumbs, hero image, title, meta bar) so it spans the full content width on desktop, matching the two-column zone below it
- Applied to both EN and FR recipe pages

## Test plan
- [ ] Open a recipe page on desktop (lg breakpoint+) and verify the hero/title/meta section is as wide as the content + sidebar below
- [ ] Verify mobile layout is unchanged (still constrained to `max-w-prose`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)