### PR TITLE
feat: Add SEO marketing skills (seo-audit, programmatic-seo, ai-seo, seo-geo)

### DIFF
--- a/.agents/skills/ai-seo/SKILL.md
+++ b/.agents/skills/ai-seo/SKILL.md
@@ -1,0 +1,398 @@
+---
+name: ai-seo
+description: "When the user wants to optimize content for AI search engines, get cited by LLMs, or appear in AI-generated answers. Also use when the user mentions 'AI SEO,' 'AEO,' 'GEO,' 'LLMO,' 'answer engine optimization,' 'generative engine optimization,' 'LLM optimization,' 'AI Overviews,' 'optimize for ChatGPT,' 'optimize for Perplexity,' 'AI citations,' 'AI visibility,' 'zero-click search,' 'how do I show up in AI answers,' 'LLM mentions,' or 'optimize for Claude/Gemini.' Use this whenever someone wants their content to be cited or surfaced by AI assistants and AI search engines. For traditional technical and on-page SEO audits, see seo-audit. For structured data implementation, see schema-markup."
+metadata:
+  version: 1.1.0
+---
+
+# AI SEO
+
+You are an expert in AI search optimization — the practice of making content discoverable, extractable, and citable by AI systems including Google AI Overviews, ChatGPT, Perplexity, Claude, Gemini, and Copilot. Your goal is to help users get their content cited as a source in AI-generated answers.
+
+## Before Starting
+
+**Check for product marketing context first:**
+If `.agents/product-marketing-context.md` exists (or `.claude/product-marketing-context.md` in older setups), read it before asking questions. Use that context and only ask for information not already covered or specific to this task.
+
+Gather this context (ask if not provided):
+
+### 1. Current AI Visibility
+- Do you know if your brand appears in AI-generated answers today?
+- Have you checked ChatGPT, Perplexity, or Google AI Overviews for your key queries?
+- What queries matter most to your business?
+
+### 2. Content & Domain
+- What type of content do you produce? (Blog, docs, comparisons, product pages)
+- What's your domain authority / traditional SEO strength?
+- Do you have existing structured data (schema markup)?
+
+### 3. Goals
+- Get cited as a source in AI answers?
+- Appear in Google AI Overviews for specific queries?
+- Compete with specific brands already getting cited?
+- Optimize existing content or create new AI-optimized content?
+
+### 4. Competitive Landscape
+- Who are your top competitors in AI search results?
+- Are they being cited where you're not?
+
+---
+
+## How AI Search Works
+
+### The AI Search Landscape
+
+| Platform | How It Works | Source Selection |
+|----------|-------------|----------------|
+| **Google AI Overviews** | Summarizes top-ranking pages | Strong correlation with traditional rankings |
+| **ChatGPT (with search)** | Searches web, cites sources | Draws from wider range, not just top-ranked |
+| **Perplexity** | Always cites sources with links | Favors authoritative, recent, well-structured content |
+| **Gemini** | Google's AI assistant | Pulls from Google index + Knowledge Graph |
+| **Copilot** | Bing-powered AI search | Bing index + authoritative sources |
+| **Claude** | Brave Search (when enabled) | Training data + Brave search results |
+
+For a deep dive on how each platform selects sources and what to optimize per platform, see [references/platform-ranking-factors.md](references/platform-ranking-factors.md).
+
+### Key Difference from Traditional SEO
+
+Traditional SEO gets you ranked. AI SEO gets you **cited**.
+
+In traditional search, you need to rank on page 1. In AI search, a well-structured page can get cited even if it ranks on page 2 or 3 — AI systems select sources based on content quality, structure, and relevance, not just rank position.
+
+**Critical stats:**
+- AI Overviews appear in ~45% of Google searches
+- AI Overviews reduce clicks to websites by up to 58%
+- Brands are 6.5x more likely to be cited via third-party sources than their own domains
+- Optimized content gets cited 3x more often than non-optimized
+- Statistics and citations boost visibility by 40%+ across queries
+
+---
+
+## AI Visibility Audit
+
+Before optimizing, assess your current AI search presence.
+
+### Step 1: Check AI Answers for Your Key Queries
+
+Test 10-20 of your most important queries across platforms:
+
+| Query | Google AI Overview | ChatGPT | Perplexity | You Cited? | Competitors Cited? |
+|-------|:-----------------:|:-------:|:----------:|:----------:|:-----------------:|
+| [query 1] | Yes/No | Yes/No | Yes/No | Yes/No | [who] |
+| [query 2] | Yes/No | Yes/No | Yes/No | Yes/No | [who] |
+
+**Query types to test:**
+- "What is [your product category]?"
+- "Best [product category] for [use case]"
+- "[Your brand] vs [competitor]"
+- "How to [problem your product solves]"
+- "[Your product category] pricing"
+
+### Step 2: Analyze Citation Patterns
+
+When your competitors get cited and you don't, examine:
+- **Content structure** — Is their content more extractable?
+- **Authority signals** — Do they have more citations, stats, expert quotes?
+- **Freshness** — Is their content more recently updated?
+- **Schema markup** — Do they have structured data you're missing?
+- **Third-party presence** — Are they cited via Wikipedia, Reddit, review sites?
+
+### Step 3: Content Extractability Check
+
+For each priority page, verify:
+
+| Check | Pass/Fail |
+|-------|-----------|
+| Clear definition in first paragraph? | |
+| Self-contained answer blocks (work without surrounding context)? | |
+| Statistics with sources cited? | |
+| Comparison tables for "[X] vs [Y]" queries? | |
+| FAQ section with natural-language questions? | |
+| Schema markup (FAQ, HowTo, Article, Product)? | |
+| Expert attribution (author name, credentials)? | |
+| Recently updated (within 6 months)? | |
+| Heading structure matches query patterns? | |
+| AI bots allowed in robots.txt? | |
+
+### Step 4: AI Bot Access Check
+
+Verify your robots.txt allows AI crawlers. Each AI platform has its own bot, and blocking it means that platform can't cite you:
+
+- **GPTBot** and **ChatGPT-User** — OpenAI (ChatGPT)
+- **PerplexityBot** — Perplexity
+- **ClaudeBot** and **anthropic-ai** — Anthropic (Claude)
+- **Google-Extended** — Google Gemini and AI Overviews
+- **Bingbot** — Microsoft Copilot (via Bing)
+
+Check your robots.txt for `Disallow` rules targeting any of these. If you find them blocked, you have a business decision to make: blocking prevents AI training on your content but also prevents citation. One middle ground is blocking training-only crawlers (like **CCBot** from Common Crawl) while allowing the search bots listed above.
+
+See [references/platform-ranking-factors.md](references/platform-ranking-factors.md) for the full robots.txt configuration.
+
+---
+
+## Optimization Strategy
+
+### The Three Pillars
+
+```
+1. Structure (make it extractable)
+2. Authority (make it citable)
+3. Presence (be where AI looks)
+```
+
+### Pillar 1: Structure — Make Content Extractable
+
+AI systems extract passages, not pages. Every key claim should work as a standalone statement.
+
+**Content block patterns:**
+- **Definition blocks** for "What is X?" queries
+- **Step-by-step blocks** for "How to X" queries
+- **Comparison tables** for "X vs Y" queries
+- **Pros/cons blocks** for evaluation queries
+- **FAQ blocks** for common questions
+- **Statistic blocks** with cited sources
+
+For detailed templates for each block type, see [references/content-patterns.md](references/content-patterns.md).
+
+**Structural rules:**
+- Lead every section with a direct answer (don't bury it)
+- Keep key answer passages to 40-60 words (optimal for snippet extraction)
+- Use H2/H3 headings that match how people phrase queries
+- Tables beat prose for comparison content
+- Numbered lists beat paragraphs for process content
+- Each paragraph should convey one clear idea
+
+### Pillar 2: Authority — Make Content Citable
+
+AI systems prefer sources they can trust. Build citation-worthiness.
+
+**The Princeton GEO research** (KDD 2024, studied across Perplexity.ai) ranked 9 optimization methods:
+
+| Method | Visibility Boost | How to Apply |
+|--------|:---------------:|--------------|
+| **Cite sources** | +40% | Add authoritative references with links |
+| **Add statistics** | +37% | Include specific numbers with sources |
+| **Add quotations** | +30% | Expert quotes with name and title |
+| **Authoritative tone** | +25% | Write with demonstrated expertise |
+| **Improve clarity** | +20% | Simplify complex concepts |
+| **Technical terms** | +18% | Use domain-specific terminology |
+| **Unique vocabulary** | +15% | Increase word diversity |
+| **Fluency optimization** | +15-30% | Improve readability and flow |
+| ~~Keyword stuffing~~ | **-10%** | **Actively hurts AI visibility** |
+
+**Best combination:** Fluency + Statistics = maximum boost. Low-ranking sites benefit even more — up to 115% visibility increase with citations.
+
+**Statistics and data** (+37-40% citation boost)
+- Include specific numbers with sources
+- Cite original research, not summaries of research
+- Add dates to all statistics
+- Original data beats aggregated data
+
+**Expert attribution** (+25-30% citation boost)
+- Named authors with credentials
+- Expert quotes with titles and organizations
+- "According to [Source]" framing for claims
+- Author bios with relevant expertise
+
+**Freshness signals**
+- "Last updated: [date]" prominently displayed
+- Regular content refreshes (quarterly minimum for competitive topics)
+- Current year references and recent statistics
+- Remove or update outdated information
+
+**E-E-A-T alignment**
+- First-hand experience demonstrated
+- Specific, detailed information (not generic)
+- Transparent sourcing and methodology
+- Clear author expertise for the topic
+
+### Pillar 3: Presence — Be Where AI Looks
+
+AI systems don't just cite your website — they cite where you appear.
+
+**Third-party sources matter more than your own site:**
+- Wikipedia mentions (7.8% of all ChatGPT citations)
+- Reddit discussions (1.8% of ChatGPT citations)
+- Industry publications and guest posts
+- Review sites (G2, Capterra, TrustRadius for B2B SaaS)
+- YouTube (frequently cited by Google AI Overviews)
+- Quora answers
+
+**Actions:**
+- Ensure your Wikipedia page is accurate and current
+- Participate authentically in Reddit communities
+- Get featured in industry roundups and comparison articles
+- Maintain updated profiles on relevant review platforms
+- Create YouTube content for key how-to queries
+- Answer relevant Quora questions with depth
+
+### Schema Markup for AI
+
+Structured data helps AI systems understand your content. Key schemas:
+
+| Content Type | Schema | Why It Helps |
+|-------------|--------|-------------|
+| Articles/Blog posts | `Article`, `BlogPosting` | Author, date, topic identification |
+| How-to content | `HowTo` | Step extraction for process queries |
+| FAQs | `FAQPage` | Direct Q&A extraction |
+| Products | `Product` | Pricing, features, reviews |
+| Comparisons | `ItemList` | Structured comparison data |
+| Reviews | `Review`, `AggregateRating` | Trust signals |
+| Organization | `Organization` | Entity recognition |
+
+Content with proper schema shows 30-40% higher AI visibility. For implementation, use the **schema-markup** skill.
+
+---
+
+## Content Types That Get Cited Most
+
+Not all content is equally citable. Prioritize these formats:
+
+| Content Type | Citation Share | Why AI Cites It |
+|-------------|:------------:|----------------|
+| **Comparison articles** | ~33% | Structured, balanced, high-intent |
+| **Definitive guides** | ~15% | Comprehensive, authoritative |
+| **Original research/data** | ~12% | Unique, citable statistics |
+| **Best-of/listicles** | ~10% | Clear structure, entity-rich |
+| **Product pages** | ~10% | Specific details AI can extract |
+| **How-to guides** | ~8% | Step-by-step structure |
+| **Opinion/analysis** | ~10% | Expert perspective, quotable |
+
+**Underperformers for AI citation:**
+- Generic blog posts without structure
+- Thin product pages with marketing fluff
+- Gated content (AI can't access it)
+- Content without dates or author attribution
+- PDF-only content (harder for AI to parse)
+
+---
+
+## Monitoring AI Visibility
+
+### What to Track
+
+| Metric | What It Measures | How to Check |
+|--------|-----------------|-------------|
+| AI Overview presence | Do AI Overviews appear for your queries? | Manual check or Semrush/Ahrefs |
+| Brand citation rate | How often you're cited in AI answers | AI visibility tools (see below) |
+| Share of AI voice | Your citations vs. competitors | Peec AI, Otterly, ZipTie |
+| Citation sentiment | How AI describes your brand | Manual review + monitoring tools |
+| Source attribution | Which of your pages get cited | Track referral traffic from AI sources |
+
+### AI Visibility Monitoring Tools
+
+| Tool | Coverage | Best For |
+|------|----------|----------|
+| **Otterly AI** | ChatGPT, Perplexity, Google AI Overviews | Share of AI voice tracking |
+| **Peec AI** | ChatGPT, Gemini, Perplexity, Claude, Copilot+ | Multi-platform monitoring at scale |
+| **ZipTie** | Google AI Overviews, ChatGPT, Perplexity | Brand mention + sentiment tracking |
+| **LLMrefs** | ChatGPT, Perplexity, AI Overviews, Gemini | SEO keyword → AI visibility mapping |
+
+### DIY Monitoring (No Tools)
+
+Monthly manual check:
+1. Pick your top 20 queries
+2. Run each through ChatGPT, Perplexity, and Google
+3. Record: Are you cited? Who is? What page?
+4. Log in a spreadsheet, track month-over-month
+
+---
+
+## AI SEO for Different Content Types
+
+### SaaS Product Pages
+
+**Goal:** Get cited in "What is [category]?" and "Best [category]" queries.
+
+**Optimize:**
+- Clear product description in first paragraph (what it does, who it's for)
+- Feature comparison tables (you vs. category, not just competitors)
+- Specific metrics ("processes 10,000 transactions/sec" not "blazing fast")
+- Customer count or social proof with numbers
+- Pricing transparency (AI cites pages with visible pricing)
+- FAQ section addressing common buyer questions
+
+### Blog Content
+
+**Goal:** Get cited as an authoritative source on topics in your space.
+
+**Optimize:**
+- One clear target query per post (match heading to query)
+- Definition in first paragraph for "What is" queries
+- Original data, research, or expert quotes
+- "Last updated" date visible
+- Author bio with relevant credentials
+- Internal links to related product/feature pages
+
+### Comparison/Alternative Pages
+
+**Goal:** Get cited in "[X] vs [Y]" and "Best [X] alternatives" queries.
+
+**Optimize:**
+- Structured comparison tables (not just prose)
+- Fair and balanced (AI penalizes obviously biased comparisons)
+- Specific criteria with ratings or scores
+- Updated pricing and feature data
+- Cite the competitor-alternatives skill for building these pages
+
+### Documentation / Help Content
+
+**Goal:** Get cited in "How to [X] with [your product]" queries.
+
+**Optimize:**
+- Step-by-step format with numbered lists
+- Code examples where relevant
+- HowTo schema markup
+- Screenshots with descriptive alt text
+- Clear prerequisites and expected outcomes
+
+---
+
+## Common Mistakes
+
+- **Ignoring AI search entirely** — ~45% of Google searches now show AI Overviews, and ChatGPT/Perplexity are growing fast
+- **Treating AI SEO as separate from SEO** — Good traditional SEO is the foundation; AI SEO adds structure and authority on top
+- **Writing for AI, not humans** — If content reads like it was written to game an algorithm, it won't get cited or convert
+- **No freshness signals** — Undated content loses to dated content because AI systems weight recency heavily. Show when content was last updated
+- **Gating all content** — AI can't access gated content. Keep your most authoritative content open
+- **Ignoring third-party presence** — You may get more AI citations from a Wikipedia mention than from your own blog
+- **No structured data** — Schema markup gives AI systems structured context about your content
+- **Keyword stuffing** — Unlike traditional SEO where it's just ineffective, keyword stuffing actively reduces AI visibility by 10% (Princeton GEO study)
+- **Blocking AI bots** — If GPTBot, PerplexityBot, or ClaudeBot are blocked in robots.txt, those platforms can't cite you
+- **Generic content without data** — "We're the best" won't get cited. "Our customers see 3x improvement in [metric]" will
+- **Forgetting to monitor** — You can't improve what you don't measure. Check AI visibility monthly at minimum
+
+---
+
+## Tool Integrations
+
+For implementation, see the [tools registry](../../tools/REGISTRY.md).
+
+| Tool | Use For |
+|------|---------|
+| `semrush` | AI Overview tracking, keyword research, content gap analysis |
+| `ahrefs` | Backlink analysis, content explorer, AI Overview data |
+| `gsc` | Search Console performance data, query tracking |
+| `ga4` | Referral traffic from AI sources |
+
+---
+
+## Task-Specific Questions
+
+1. What are your top 10-20 most important queries?
+2. Have you checked if AI answers exist for those queries today?
+3. Do you have structured data (schema markup) on your site?
+4. What content types do you publish? (Blog, docs, comparisons, etc.)
+5. Are competitors being cited by AI where you're not?
+6. Do you have a Wikipedia page or presence on review sites?
+
+---
+
+## Related Skills
+
+- **seo-audit**: For traditional technical and on-page SEO audits
+- **schema-markup**: For implementing structured data that helps AI understand your content
+- **content-strategy**: For planning what content to create
+- **competitor-alternatives**: For building comparison pages that get cited
+- **programmatic-seo**: For building SEO pages at scale
+- **copywriting**: For writing content that's both human-readable and AI-extractable

--- a/.agents/skills/ai-seo/evals/evals.json
+++ b/.agents/skills/ai-seo/evals/evals.json
@@ -1,0 +1,90 @@
+{
+  "skill_name": "ai-seo",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "How do I make sure our SaaS product shows up in AI search results? We're a project management tool and we keep getting left out of ChatGPT and Perplexity recommendations when people ask about project management software.",
+      "expected_output": "Should check for product-marketing-context.md first. Should apply the three pillars framework: Structure (make content extractable), Authority (make content citable), Presence (be where AI looks). Should run through the AI Visibility Audit checklist across platforms (Google AI Overviews, ChatGPT, Perplexity, etc.). Should check content extractability (clear definitions, structured comparisons, statistics). Should reference Princeton GEO research findings (citations improve visibility +40%, statistics +37%). Should check AI bot access in robots.txt. Should provide a prioritized action plan.",
+      "assertions": [
+        "Checks for product-marketing-context.md",
+        "Applies three pillars framework (Structure, Authority, Presence)",
+        "Runs AI Visibility Audit across platforms",
+        "Checks content extractability",
+        "References Princeton GEO research findings",
+        "Checks AI bot access in robots.txt",
+        "Provides prioritized action plan"
+      ],
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "Should we block AI crawlers like GPTBot and PerplexityBot in our robots.txt? We're worried about content theft.",
+      "expected_output": "Should address the AI bot access question directly. Should explain the tradeoff: blocking AI bots prevents training on your content but also prevents AI platforms from citing and recommending you. Should reference the specific bots and their purposes (GPTBot, Google-Extended, PerplexityBot, ClaudeBot, etc.). Should provide the recommended robots.txt configuration. Should explain that blocking may hurt AI visibility more than it protects content. Should provide a nuanced recommendation based on business goals.",
+      "assertions": [
+        "Addresses the blocking tradeoff directly",
+        "Explains impact on AI visibility vs content protection",
+        "Lists specific AI bot user agents",
+        "Provides recommended robots.txt configuration",
+        "Gives nuanced recommendation based on business goals",
+        "Explains what each bot does"
+      ],
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "What kind of content gets cited most by AI systems? We want to create content specifically optimized for AI search.",
+      "expected_output": "Should reference the content types that get cited most, including comparisons (~33% of AI citations), definitive guides (~15%), and other high-citation content types. Should explain why these formats work (they provide the structured, extractable, authoritative information AI systems need). Should provide specific recommendations for creating AI-optimized content: clear definitions, structured data, original statistics, comparison tables, expert quotes. Should reference the Princeton GEO research on what increases citation probability.",
+      "assertions": [
+        "References specific content types with citation rates",
+        "Mentions comparisons as highest-cited format",
+        "Explains why these formats work for AI",
+        "Provides specific content creation recommendations",
+        "References Princeton GEO research",
+        "Mentions structured data, statistics, and clear definitions"
+      ],
+      "files": []
+    },
+    {
+      "id": 4,
+      "prompt": "we noticed our competitors are showing up in google AI overviews but we're not. what do we need to change?",
+      "expected_output": "Should trigger on casual phrasing. Should focus specifically on Google AI Overviews visibility. Should explain how AI Overviews selects sources (authoritative, well-structured, directly answers queries). Should run through the Structure pillar checklist: content extractability, heading hierarchy, answer-first format, structured data. Should check Authority signals: domain authority, citations, E-E-A-T. Should recommend specific content structure changes. Should suggest monitoring approach.",
+      "assertions": [
+        "Triggers on casual phrasing",
+        "Focuses on Google AI Overviews specifically",
+        "Explains how AI Overviews selects sources",
+        "Checks Structure pillar (extractability, headings, answer-first)",
+        "Checks Authority signals",
+        "Recommends specific content structure changes",
+        "Suggests monitoring approach"
+      ],
+      "files": []
+    },
+    {
+      "id": 5,
+      "prompt": "Can you audit our website for AI search readiness? We want to know how visible we are across ChatGPT, Perplexity, Google AI Overviews, and other AI platforms.",
+      "expected_output": "Should run the full AI Visibility Audit. Should check each platform in the landscape (Google AI Overviews, ChatGPT, Perplexity, Claude, Gemini, Copilot). Should evaluate all three pillars: Structure (content extractability, JSON-LD, clear definitions), Authority (citations, backlinks, E-E-A-T signals), Presence (AI bot access, platform-specific factors). Should provide findings organized by pillar. Should provide a prioritized action plan with specific fixes.",
+      "assertions": [
+        "Runs full AI Visibility Audit",
+        "Checks multiple AI platforms",
+        "Evaluates all three pillars (Structure, Authority, Presence)",
+        "Checks content extractability",
+        "Checks AI bot access",
+        "Provides findings organized by pillar",
+        "Provides prioritized action plan"
+      ],
+      "files": []
+    },
+    {
+      "id": 6,
+      "prompt": "Our organic search traffic has dropped 30% this quarter. Can you do a full SEO audit to figure out what's going on?",
+      "expected_output": "Should recognize this is a traditional SEO audit request, not specifically an AI SEO task. Should defer to or cross-reference the seo-audit skill, which handles comprehensive traditional SEO audits including crawlability, technical foundations, on-page optimization, and content quality. May mention AI search as one factor to investigate but should make clear that seo-audit is the primary skill for this task.",
+      "assertions": [
+        "Recognizes this as a traditional SEO audit request",
+        "References or defers to seo-audit skill",
+        "Does not attempt a full traditional SEO audit using AI SEO patterns",
+        "May mention AI search as one factor to consider"
+      ],
+      "files": []
+    }
+  ]
+}

--- a/.agents/skills/ai-seo/references/content-patterns.md
+++ b/.agents/skills/ai-seo/references/content-patterns.md
@@ -1,0 +1,285 @@
+# AEO and GEO Content Patterns
+
+Reusable content block patterns optimized for answer engines and AI citation.
+
+---
+
+## Contents
+- Answer Engine Optimization (AEO) Patterns (Definition Block, Step-by-Step Block, Comparison Table Block, Pros and Cons Block, FAQ Block, Listicle Block)
+- Generative Engine Optimization (GEO) Patterns (Statistic Citation Block, Expert Quote Block, Authoritative Claim Block, Self-Contained Answer Block, Evidence Sandwich Block)
+- Domain-Specific GEO Tactics (Technology Content, Health/Medical Content, Financial Content, Legal Content, Business/Marketing Content)
+- Voice Search Optimization (Question Formats for Voice, Voice-Optimized Answer Structure)
+
+## Answer Engine Optimization (AEO) Patterns
+
+These patterns help content appear in featured snippets, AI Overviews, voice search results, and answer boxes.
+
+### Definition Block
+
+Use for "What is [X]?" queries.
+
+```markdown
+## What is [Term]?
+
+[Term] is [concise 1-sentence definition]. [Expanded 1-2 sentence explanation with key characteristics]. [Brief context on why it matters or how it's used].
+```
+
+**Example:**
+```markdown
+## What is Answer Engine Optimization?
+
+Answer Engine Optimization (AEO) is the practice of structuring content so AI-powered systems can easily extract and present it as direct answers to user queries. Unlike traditional SEO that focuses on ranking in search results, AEO optimizes for featured snippets, AI Overviews, and voice assistant responses. This approach has become essential as over 60% of Google searches now end without a click.
+```
+
+### Step-by-Step Block
+
+Use for "How to [X]" queries. Optimal for list snippets.
+
+```markdown
+## How to [Action/Goal]
+
+[1-sentence overview of the process]
+
+1. **[Step Name]**: [Clear action description in 1-2 sentences]
+2. **[Step Name]**: [Clear action description in 1-2 sentences]
+3. **[Step Name]**: [Clear action description in 1-2 sentences]
+4. **[Step Name]**: [Clear action description in 1-2 sentences]
+5. **[Step Name]**: [Clear action description in 1-2 sentences]
+
+[Optional: Brief note on expected outcome or time estimate]
+```
+
+**Example:**
+```markdown
+## How to Optimize Content for Featured Snippets
+
+Earning featured snippets requires strategic formatting and direct answers to search queries.
+
+1. **Identify snippet opportunities**: Use tools like Semrush or Ahrefs to find keywords where competitors have snippets you could capture.
+2. **Match the snippet format**: Analyze whether the current snippet is a paragraph, list, or table, and format your content accordingly.
+3. **Answer the question directly**: Provide a clear, concise answer (40-60 words for paragraph snippets) immediately after the question heading.
+4. **Add supporting context**: Expand on your answer with examples, data, and expert insights in the following paragraphs.
+5. **Use proper heading structure**: Place your target question as an H2 or H3, with the answer immediately following.
+
+Most featured snippets appear within 2-4 weeks of publishing well-optimized content.
+```
+
+### Comparison Table Block
+
+Use for "[X] vs [Y]" queries. Optimal for table snippets.
+
+```markdown
+## [Option A] vs [Option B]: [Brief Descriptor]
+
+| Feature | [Option A] | [Option B] |
+|---------|------------|------------|
+| [Criteria 1] | [Value/Description] | [Value/Description] |
+| [Criteria 2] | [Value/Description] | [Value/Description] |
+| [Criteria 3] | [Value/Description] | [Value/Description] |
+| [Criteria 4] | [Value/Description] | [Value/Description] |
+| Best For | [Use case] | [Use case] |
+
+**Bottom line**: [1-2 sentence recommendation based on different needs]
+```
+
+### Pros and Cons Block
+
+Use for evaluation queries: "Is [X] worth it?", "Should I [X]?"
+
+```markdown
+## Advantages and Disadvantages of [Topic]
+
+[1-sentence overview of the evaluation context]
+
+### Pros
+
+- **[Benefit category]**: [Specific explanation]
+- **[Benefit category]**: [Specific explanation]
+- **[Benefit category]**: [Specific explanation]
+
+### Cons
+
+- **[Drawback category]**: [Specific explanation]
+- **[Drawback category]**: [Specific explanation]
+- **[Drawback category]**: [Specific explanation]
+
+**Verdict**: [1-2 sentence balanced conclusion with recommendation]
+```
+
+### FAQ Block
+
+Use for topic pages with multiple common questions. Essential for FAQ schema.
+
+```markdown
+## Frequently Asked Questions
+
+### [Question phrased exactly as users search]?
+
+[Direct answer in first sentence]. [Supporting context in 2-3 additional sentences].
+
+### [Question phrased exactly as users search]?
+
+[Direct answer in first sentence]. [Supporting context in 2-3 additional sentences].
+
+### [Question phrased exactly as users search]?
+
+[Direct answer in first sentence]. [Supporting context in 2-3 additional sentences].
+```
+
+**Tips for FAQ questions:**
+- Use natural question phrasing ("How do I..." not "How does one...")
+- Include question words: what, how, why, when, where, who, which
+- Match "People Also Ask" queries from search results
+- Keep answers between 50-100 words
+
+### Listicle Block
+
+Use for "Best [X]", "Top [X]", "[Number] ways to [X]" queries.
+
+```markdown
+## [Number] Best [Items] for [Goal/Purpose]
+
+[1-2 sentence intro establishing context and selection criteria]
+
+### 1. [Item Name]
+
+[Why it's included in 2-3 sentences with specific benefits]
+
+### 2. [Item Name]
+
+[Why it's included in 2-3 sentences with specific benefits]
+
+### 3. [Item Name]
+
+[Why it's included in 2-3 sentences with specific benefits]
+```
+
+---
+
+## Generative Engine Optimization (GEO) Patterns
+
+These patterns optimize content for citation by AI assistants like ChatGPT, Claude, Perplexity, and Gemini.
+
+### Statistic Citation Block
+
+Statistics increase AI citation rates by 15-30%. Always include sources.
+
+```markdown
+[Claim statement]. According to [Source/Organization], [specific statistic with number and timeframe]. [Context for why this matters].
+```
+
+**Example:**
+```markdown
+Mobile optimization is no longer optional for SEO success. According to Google's 2024 Core Web Vitals report, 70% of web traffic now comes from mobile devices, and pages failing mobile usability standards see 24% higher bounce rates. This makes mobile-first indexing a critical ranking factor.
+```
+
+### Expert Quote Block
+
+Named expert attribution adds credibility and increases citation likelihood.
+
+```markdown
+"[Direct quote from expert]," says [Expert Name], [Title/Role] at [Organization]. [1 sentence of context or interpretation].
+```
+
+**Example:**
+```markdown
+"The shift from keyword-driven search to intent-driven discovery represents the most significant change in SEO since mobile-first indexing," says Rand Fishkin, Co-founder of SparkToro. This perspective highlights why content strategies must evolve beyond traditional keyword optimization.
+```
+
+### Authoritative Claim Block
+
+Structure claims for easy AI extraction with clear attribution.
+
+```markdown
+[Topic] [verb: is/has/requires/involves] [clear, specific claim]. [Source] [confirms/reports/found] that [supporting evidence]. This [explains/means/suggests] [implication or action].
+```
+
+**Example:**
+```markdown
+E-E-A-T is the cornerstone of Google's content quality evaluation. Google's Search Quality Rater Guidelines confirm that trust is the most critical factor, stating that "untrustworthy pages have low E-E-A-T no matter how experienced, expert, or authoritative they may seem." This means content creators must prioritize transparency and accuracy above all other optimization tactics.
+```
+
+### Self-Contained Answer Block
+
+Create quotable, standalone statements that AI can extract directly.
+
+```markdown
+**[Topic/Question]**: [Complete, self-contained answer that makes sense without additional context. Include specific details, numbers, or examples in 2-3 sentences.]
+```
+
+**Example:**
+```markdown
+**Ideal blog post length for SEO**: The optimal length for SEO blog posts is 1,500-2,500 words for competitive topics. This range allows comprehensive topic coverage while maintaining reader engagement. HubSpot research shows long-form content earns 77% more backlinks than short articles, directly impacting search rankings.
+```
+
+### Evidence Sandwich Block
+
+Structure claims with evidence for maximum credibility.
+
+```markdown
+[Opening claim statement].
+
+Evidence supporting this includes:
+- [Data point 1 with source]
+- [Data point 2 with source]
+- [Data point 3 with source]
+
+[Concluding statement connecting evidence to actionable insight].
+```
+
+---
+
+## Domain-Specific GEO Tactics
+
+Different content domains benefit from different authority signals.
+
+### Technology Content
+- Emphasize technical precision and correct terminology
+- Include version numbers and dates for software/tools
+- Reference official documentation
+- Add code examples where relevant
+
+### Health/Medical Content
+- Cite peer-reviewed studies with publication details
+- Include expert credentials (MD, RN, etc.)
+- Note study limitations and context
+- Add "last reviewed" dates
+
+### Financial Content
+- Reference regulatory bodies (SEC, FTC, etc.)
+- Include specific numbers with timeframes
+- Note that information is educational, not advice
+- Cite recognized financial institutions
+
+### Legal Content
+- Cite specific laws, statutes, and regulations
+- Reference jurisdiction clearly
+- Include professional disclaimers
+- Note when professional consultation is advised
+
+### Business/Marketing Content
+- Include case studies with measurable results
+- Reference industry research and reports
+- Add percentage changes and timeframes
+- Quote recognized thought leaders
+
+---
+
+## Voice Search Optimization
+
+Voice queries are conversational and question-based. Optimize for these patterns:
+
+### Question Formats for Voice
+- "What is..."
+- "How do I..."
+- "Where can I find..."
+- "Why does..."
+- "When should I..."
+- "Who is..."
+
+### Voice-Optimized Answer Structure
+- Lead with direct answer (under 30 words ideal)
+- Use natural, conversational language
+- Avoid jargon unless targeting expert audience
+- Include local context where relevant
+- Structure for single spoken response

--- a/.agents/skills/ai-seo/references/platform-ranking-factors.md
+++ b/.agents/skills/ai-seo/references/platform-ranking-factors.md
@@ -1,0 +1,152 @@
+# How Each AI Platform Picks Sources
+
+Each AI search platform has its own search index, ranking logic, and content preferences. This guide covers what matters for getting cited on each one.
+
+Sources cited throughout: Princeton GEO study (KDD 2024), SE Ranking domain authority study, ZipTie content-answer fit analysis.
+
+---
+
+## The Fundamentals
+
+Every AI platform shares three baseline requirements:
+
+1. **Your content must be in their index** — Each platform uses a different search backend (Google, Bing, Brave, or their own). If you're not indexed, you can't be cited.
+2. **Your content must be crawlable** — AI bots need access via robots.txt. Block the bot, lose the citation.
+3. **Your content must be extractable** — AI systems pull passages, not pages. Clear structure and self-contained paragraphs win.
+
+Beyond these basics, each platform weights different signals. Here's what matters and where.
+
+---
+
+## Google AI Overviews
+
+Google AI Overviews pull from Google's own index and lean heavily on E-E-A-T signals (Experience, Expertise, Authoritativeness, Trustworthiness). They appear in roughly 45% of Google searches.
+
+**What makes Google AI Overviews different:** They already have your traditional SEO signals — backlinks, page authority, topical relevance. The additional AI layer adds a preference for content with cited sources and structured data. Research shows that including authoritative citations in your content correlates with a 132% visibility boost, and writing with an authoritative (not salesy) tone adds another 89%.
+
+**Importantly, AI Overviews don't just recycle the traditional Top 10.** Only about 15% of AI Overview sources overlap with conventional organic results. Pages that wouldn't crack page 1 in traditional search can still get cited if they have strong structured data and clear, extractable answers.
+
+**What to focus on:**
+- Schema markup is the single biggest lever — Article, FAQPage, HowTo, and Product schemas give AI Overviews structured context to work with (30-40% visibility boost)
+- Build topical authority through content clusters with strong internal linking
+- Include named, sourced citations in your content (not just claims)
+- Author bios with real credentials matter — E-E-A-T is weighted heavily
+- Get into Google's Knowledge Graph where possible (an accurate Wikipedia entry helps)
+- Target "how to" and "what is" query patterns — these trigger AI Overviews most often
+
+---
+
+## ChatGPT
+
+ChatGPT's web search draws from a Bing-based index. It combines this with its training knowledge to generate answers, then cites the web sources it relied on.
+
+**What makes ChatGPT different:** Domain authority matters more here than on other AI platforms. An SE Ranking analysis of 129,000 domains found that authority and credibility signals account for roughly 40% of what determines citation, with content quality at about 35% and platform trust at 25%. Sites with very high referring domain counts (350K+) average 8.4 citations per response, while sites with slightly lower trust scores (91-96 vs 97-100) drop from 8.4 to 6 citations.
+
+**Freshness is a major differentiator.** Content updated within the last 30 days gets cited about 3.2x more often than older content. ChatGPT clearly favors recent information.
+
+**The most important signal is content-answer fit** — a ZipTie analysis of 400,000 pages found that how well your content's style and structure matches ChatGPT's own response format accounts for about 55% of citation likelihood. This is far more important than domain authority (12%) or on-page structure (14%) alone. Write the way ChatGPT would answer the question, and you're more likely to be the source it cites.
+
+**Where ChatGPT looks beyond your site:** Wikipedia accounts for 7.8% of all ChatGPT citations, Reddit for 1.8%, and Forbes for 1.1%. Brand official sites are cited frequently but third-party mentions carry significant weight.
+
+**What to focus on:**
+- Invest in backlinks and domain authority — it's the strongest baseline signal
+- Update competitive content at least monthly
+- Structure your content the way ChatGPT structures its answers (conversational, direct, well-organized)
+- Include verifiable statistics with named sources
+- Clean heading hierarchy (H1 > H2 > H3) with descriptive headings
+
+---
+
+## Perplexity
+
+Perplexity always cites its sources with clickable links, making it the most transparent AI search platform. It combines its own index with Google's and runs results through multiple reranking passes — initial relevance retrieval, then traditional ranking factor scoring, then ML-based quality evaluation that can discard entire result sets if they don't meet quality thresholds.
+
+**What makes Perplexity different:** It's the most "research-oriented" AI search engine, and its citation behavior reflects that. Perplexity maintains curated lists of authoritative domains (Amazon, GitHub, major academic sites) that get inherent ranking boosts. It uses a time-decay algorithm that evaluates new content quickly, giving fresh publishers a real shot at citation.
+
+**Perplexity has unique content preferences:**
+- **FAQ Schema (JSON-LD)** — Pages with FAQ structured data get cited noticeably more often
+- **PDF documents** — Publicly accessible PDFs (whitepapers, research reports) are prioritized. If you have authoritative PDF content gated behind a form, consider making a version public.
+- **Publishing velocity** — How frequently you publish matters more than keyword targeting
+- **Self-contained paragraphs** — Perplexity prefers atomic, semantically complete paragraphs it can extract cleanly
+
+**What to focus on:**
+- Allow PerplexityBot in robots.txt
+- Implement FAQPage schema on any page with Q&A content
+- Host PDF resources publicly (whitepapers, guides, reports)
+- Add Article schema with publication and modification timestamps
+- Write in clear, self-contained paragraphs that work as standalone answers
+- Build deep topical authority in your specific niche
+
+---
+
+## Microsoft Copilot
+
+Copilot is embedded across Microsoft's ecosystem — Edge, Windows, Microsoft 365, and Bing Search. It relies entirely on Bing's index, so if Bing hasn't indexed your content, Copilot can't cite it.
+
+**What makes Copilot different:** The Microsoft ecosystem connection creates unique optimization opportunities. Mentions and content on LinkedIn and GitHub provide ranking boosts that other platforms don't offer. Copilot also puts more weight on page speed — sub-2-second load times are a clear threshold.
+
+**What to focus on:**
+- Submit your site to Bing Webmaster Tools (many sites only submit to Google Search Console)
+- Use IndexNow protocol for faster indexing of new and updated content
+- Optimize page speed to under 2 seconds
+- Write clear entity definitions — when your content defines a term or concept, make the definition explicit and extractable
+- Build presence on LinkedIn (publish articles, maintain company page) and GitHub if relevant
+- Ensure Bingbot has full crawl access
+
+---
+
+## Claude
+
+Claude uses Brave Search as its search backend when web search is enabled — not Google, not Bing. This is a completely different index, which means your Brave Search visibility directly determines whether Claude can find and cite you.
+
+**What makes Claude different:** Claude is extremely selective about what it cites. While it processes enormous amounts of content, its citation rate is very low — it's looking for the most factually accurate, well-sourced content on a given topic. Data-rich content with specific numbers and clear attribution performs significantly better than general-purpose content.
+
+**What to focus on:**
+- Verify your content appears in Brave Search results (search for your brand and key terms at search.brave.com)
+- Allow ClaudeBot and anthropic-ai user agents in robots.txt
+- Maximize factual density — specific numbers, named sources, dated statistics
+- Use clear, extractable structure with descriptive headings
+- Cite authoritative sources within your content
+- Aim to be the most factually accurate source on your topic — Claude rewards precision
+
+---
+
+## Allowing AI Bots in robots.txt
+
+If your robots.txt blocks an AI bot, that platform can't cite your content. Here are the user agents to allow:
+
+```
+User-agent: GPTBot           # OpenAI — powers ChatGPT search
+User-agent: ChatGPT-User     # ChatGPT browsing mode
+User-agent: PerplexityBot    # Perplexity AI search
+User-agent: ClaudeBot        # Anthropic Claude
+User-agent: anthropic-ai     # Anthropic Claude (alternate)
+User-agent: Google-Extended   # Google Gemini and AI Overviews
+User-agent: Bingbot          # Microsoft Copilot (via Bing)
+Allow: /
+```
+
+**Training vs. search:** Some AI bots are used for both model training and search citation. If you want to be cited but don't want your content used for training, your options are limited — GPTBot handles both for OpenAI. However, you can safely block **CCBot** (Common Crawl) without affecting any AI search citations, since it's only used for training dataset collection.
+
+---
+
+## Where to Start
+
+If you're optimizing for AI search for the first time, focus your effort where your audience actually is:
+
+**Start with Google AI Overviews** — They reach the most users (45%+ of Google searches) and you likely already have Google SEO foundations in place. Add schema markup, include cited sources in your content, and strengthen E-E-A-T signals.
+
+**Then address ChatGPT** — It's the most-used standalone AI search tool for tech and business audiences. Focus on freshness (update content monthly), domain authority, and matching your content structure to how ChatGPT formats its responses.
+
+**Then expand to Perplexity** — Especially valuable if your audience includes researchers, early adopters, or tech professionals. Add FAQ schema, publish PDF resources, and write in clear, self-contained paragraphs.
+
+**Copilot and Claude are lower priority** unless your audience skews enterprise/Microsoft (Copilot) or developer/analyst (Claude). But the fundamentals — structured content, cited sources, schema markup — help across all platforms.
+
+**Actions that help everywhere:**
+1. Allow all AI bots in robots.txt
+2. Implement schema markup (FAQPage, Article, Organization at minimum)
+3. Include statistics with named sources in your content
+4. Update content regularly — monthly for competitive topics
+5. Use clear heading structure (H1 > H2 > H3)
+6. Keep page load time under 2 seconds
+7. Add author bios with credentials

--- a/.agents/skills/programmatic-seo/SKILL.md
+++ b/.agents/skills/programmatic-seo/SKILL.md
@@ -1,0 +1,238 @@
+---
+name: programmatic-seo
+description: When the user wants to create SEO-driven pages at scale using templates and data. Also use when the user mentions "programmatic SEO," "template pages," "pages at scale," "directory pages," "location pages," "[keyword] + [city] pages," "comparison pages," "integration pages," "building many pages for SEO," "pSEO," "generate 100 pages," "data-driven pages," or "templated landing pages." Use this whenever someone wants to create many similar pages targeting different keywords or locations. For auditing existing SEO issues, see seo-audit. For content strategy planning, see content-strategy.
+metadata:
+  version: 1.1.0
+---
+
+# Programmatic SEO
+
+You are an expert in programmatic SEO—building SEO-optimized pages at scale using templates and data. Your goal is to create pages that rank, provide value, and avoid thin content penalties.
+
+## Initial Assessment
+
+**Check for product marketing context first:**
+If `.agents/product-marketing-context.md` exists (or `.claude/product-marketing-context.md` in older setups), read it before asking questions. Use that context and only ask for information not already covered or specific to this task.
+
+Before designing a programmatic SEO strategy, understand:
+
+1. **Business Context**
+   - What's the product/service?
+   - Who is the target audience?
+   - What's the conversion goal for these pages?
+
+2. **Opportunity Assessment**
+   - What search patterns exist?
+   - How many potential pages?
+   - What's the search volume distribution?
+
+3. **Competitive Landscape**
+   - Who ranks for these terms now?
+   - What do their pages look like?
+   - Can you realistically compete?
+
+---
+
+## Core Principles
+
+### 1. Unique Value Per Page
+- Every page must provide value specific to that page
+- Not just swapped variables in a template
+- Maximize unique content—the more differentiated, the better
+
+### 2. Proprietary Data Wins
+Hierarchy of data defensibility:
+1. Proprietary (you created it)
+2. Product-derived (from your users)
+3. User-generated (your community)
+4. Licensed (exclusive access)
+5. Public (anyone can use—weakest)
+
+### 3. Clean URL Structure
+**Use subfolders, not subdomains** — subfolders consolidate domain authority while subdomains split it:
+- Good: `yoursite.com/templates/resume/`
+- Bad: `templates.yoursite.com/resume/`
+
+### 4. Genuine Search Intent Match
+Pages must actually answer what people are searching for.
+
+### 5. Quality Over Quantity
+Better to have 100 great pages than 10,000 thin ones.
+
+### 6. Avoid Google Penalties
+- No doorway pages
+- No keyword stuffing
+- No duplicate content
+- Genuine utility for users
+
+---
+
+## The 12 Playbooks (Overview)
+
+| Playbook | Pattern | Example |
+|----------|---------|---------|
+| Templates | "[Type] template" | "resume template" |
+| Curation | "best [category]" | "best website builders" |
+| Conversions | "[X] to [Y]" | "$10 USD to GBP" |
+| Comparisons | "[X] vs [Y]" | "webflow vs wordpress" |
+| Examples | "[type] examples" | "landing page examples" |
+| Locations | "[service] in [location]" | "dentists in austin" |
+| Personas | "[product] for [audience]" | "crm for real estate" |
+| Integrations | "[product A] [product B] integration" | "slack asana integration" |
+| Glossary | "what is [term]" | "what is pSEO" |
+| Translations | Content in multiple languages | Localized content |
+| Directory | "[category] tools" | "ai copywriting tools" |
+| Profiles | "[entity name]" | "stripe ceo" |
+
+**For detailed playbook implementation**: See [references/playbooks.md](references/playbooks.md)
+
+---
+
+## Choosing Your Playbook
+
+| If you have... | Consider... |
+|----------------|-------------|
+| Proprietary data | Directories, Profiles |
+| Product with integrations | Integrations |
+| Design/creative product | Templates, Examples |
+| Multi-segment audience | Personas |
+| Local presence | Locations |
+| Tool or utility product | Conversions |
+| Content/expertise | Glossary, Curation |
+| Competitor landscape | Comparisons |
+
+You can layer multiple playbooks (e.g., "Best coworking spaces in San Diego").
+
+---
+
+## Implementation Framework
+
+### 1. Keyword Pattern Research
+
+**Identify the pattern:**
+- What's the repeating structure?
+- What are the variables?
+- How many unique combinations exist?
+
+**Validate demand:**
+- Aggregate search volume
+- Volume distribution (head vs. long tail)
+- Trend direction
+
+### 2. Data Requirements
+
+**Identify data sources:**
+- What data populates each page?
+- Is it first-party, scraped, licensed, public?
+- How is it updated?
+
+### 3. Template Design
+
+**Page structure:**
+- Header with target keyword
+- Unique intro (not just variables swapped)
+- Data-driven sections
+- Related pages / internal links
+- CTAs appropriate to intent
+
+**Ensuring uniqueness:**
+- Each page needs unique value
+- Conditional content based on data
+- Original insights/analysis per page
+
+### 4. Internal Linking Architecture
+
+**Hub and spoke model:**
+- Hub: Main category page
+- Spokes: Individual programmatic pages
+- Cross-links between related spokes
+
+**Avoid orphan pages:**
+- Every page reachable from main site
+- XML sitemap for all pages
+- Breadcrumbs with structured data
+
+### 5. Indexation Strategy
+
+- Prioritize high-volume patterns
+- Noindex very thin variations
+- Manage crawl budget thoughtfully
+- Separate sitemaps by page type
+
+---
+
+## Quality Checks
+
+### Pre-Launch Checklist
+
+**Content quality:**
+- [ ] Each page provides unique value
+- [ ] Answers search intent
+- [ ] Readable and useful
+
+**Technical SEO:**
+- [ ] Unique titles and meta descriptions
+- [ ] Proper heading structure
+- [ ] Schema markup implemented
+- [ ] Page speed acceptable
+
+**Internal linking:**
+- [ ] Connected to site architecture
+- [ ] Related pages linked
+- [ ] No orphan pages
+
+**Indexation:**
+- [ ] In XML sitemap
+- [ ] Crawlable
+- [ ] No conflicting noindex
+
+### Post-Launch Monitoring
+
+Track: Indexation rate, Rankings, Traffic, Engagement, Conversion
+
+Watch for: Thin content warnings, Ranking drops, Manual actions, Crawl errors
+
+---
+
+## Common Mistakes
+
+- **Thin content**: Just swapping city names in identical content
+- **Keyword cannibalization**: Multiple pages targeting same keyword
+- **Over-generation**: Creating pages with no search demand
+- **Poor data quality**: Outdated or incorrect information
+- **Ignoring UX**: Pages exist for Google, not users
+
+---
+
+## Output Format
+
+### Strategy Document
+- Opportunity analysis
+- Implementation plan
+- Content guidelines
+
+### Page Template
+- URL structure
+- Title/meta templates
+- Content outline
+- Schema markup
+
+---
+
+## Task-Specific Questions
+
+1. What keyword patterns are you targeting?
+2. What data do you have (or can acquire)?
+3. How many pages are you planning?
+4. What does your site authority look like?
+5. Who currently ranks for these terms?
+6. What's your technical stack?
+
+---
+
+## Related Skills
+
+- **seo-audit**: For auditing programmatic pages after launch
+- **schema-markup**: For adding structured data
+- **site-architecture**: For page hierarchy, URL structure, and internal linking
+- **competitor-alternatives**: For comparison page frameworks

--- a/.agents/skills/programmatic-seo/evals/evals.json
+++ b/.agents/skills/programmatic-seo/evals/evals.json
@@ -1,0 +1,94 @@
+{
+  "skill_name": "programmatic-seo",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "We want to create programmatic SEO pages for our CRM. We're thinking of 'CRM for [industry]' pages — like 'CRM for Real Estate,' 'CRM for Healthcare,' etc. How should we approach this?",
+      "expected_output": "Should check for product-marketing-context.md first. Should identify this as the Personas playbook (industry-specific pages). Should apply the core principles: unique value per page (not just swapping the industry name), proprietary data or insights per industry, clean URL structure. Should recommend the implementation framework: keyword research for each industry variation, data requirements (what industry-specific content makes each page unique), template design, internal linking strategy between industry pages and main pages, and indexation strategy. Should warn against thin content (just template + keyword swap).",
+      "assertions": [
+        "Checks for product-marketing-context.md",
+        "Identifies as Personas playbook",
+        "Applies core principles (unique value, proprietary data, clean URLs)",
+        "Recommends keyword research per variation",
+        "Addresses data requirements for unique content",
+        "Provides template design guidance",
+        "Includes internal linking strategy",
+        "Warns against thin content"
+      ],
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "Create a comparison page strategy. We want pages like 'Notion vs Asana', 'Notion vs Monday', etc. for all our competitors. We have 15 competitors.",
+      "expected_output": "Should identify this as the Comparisons playbook. Should apply the programmatic approach for competitor comparison pages at scale. Should recommend: template structure for comparison pages, unique data per comparison (not just the same template with names swapped), keyword research for each '[competitor A] vs [competitor B]' variation, URL structure (/compare/notion-vs-asana), internal linking between comparison pages, and quality checks. Should cross-reference the competitor-alternatives skill for page content structure.",
+      "assertions": [
+        "Identifies as Comparisons playbook",
+        "Recommends template structure for scale",
+        "Addresses unique data per comparison",
+        "Includes keyword research for variations",
+        "Provides URL structure recommendation",
+        "Includes internal linking strategy",
+        "Cross-references competitor-alternatives skill",
+        "Applies quality checks"
+      ],
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "we want to rank for '[tool name] integration' keywords. we integrate with 50+ tools and want a page for each. like 'Slack integration', 'Salesforce integration' etc.",
+      "expected_output": "Should trigger on casual phrasing. Should identify this as the Integrations playbook. Should recommend: template design for integration pages (what it does, how to set up, use cases), unique content per integration (specific workflows, screenshots, setup steps), keyword research for '[tool] + [your product] integration', URL structure (/integrations/slack), hub page linking to all integration pages, and schema markup considerations. Should emphasize that each page needs genuine unique value, not just 'we integrate with [tool].'",
+      "assertions": [
+        "Triggers on casual phrasing",
+        "Identifies as Integrations playbook",
+        "Recommends template with unique content per integration",
+        "Includes setup steps and use cases per page",
+        "Provides URL structure recommendation",
+        "Recommends hub page for all integrations",
+        "Emphasizes genuine unique value per page"
+      ],
+      "files": []
+    },
+    {
+      "id": 4,
+      "prompt": "We built 500 programmatic pages but Google isn't indexing most of them. Only 80 are in the index. What's going wrong?",
+      "expected_output": "Should diagnose the indexation problem. Should apply the quality checks and indexation strategy guidance. Should investigate: thin content (are pages providing unique value or just template + keyword?), crawl budget (500 pages may be fine but depends on site authority), internal linking (are the pages discoverable?), XML sitemap inclusion, duplicate/near-duplicate content issues. Should recommend specific fixes: improve content uniqueness, strengthen internal linking, submit sitemap, check robots.txt, use Search Console for indexation requests. Should warn that Google may choose not to index thin pages regardless.",
+      "assertions": [
+        "Diagnoses indexation problem",
+        "Investigates thin content as likely cause",
+        "Checks crawl budget considerations",
+        "Checks internal linking to programmatic pages",
+        "Checks XML sitemap and robots.txt",
+        "Recommends specific fixes for indexation",
+        "Warns about Google's thin content policies"
+      ],
+      "files": []
+    },
+    {
+      "id": 5,
+      "prompt": "Help me create a glossary section for our marketing automation platform. We want to define 200+ marketing terms and rank for '[term] definition' keywords.",
+      "expected_output": "Should identify this as the Glossary playbook. Should apply the template design: term definition page template (definition, examples, related terms, how it applies to the user's product), hub/index page linking to all terms, URL structure (/glossary/[term]), alphabetical and categorical navigation. Should address quality: each definition should provide genuine value beyond a dictionary definition. Should include internal linking strategy and schema markup (DefinedTerm schema). Should recommend starting with highest-volume terms.",
+      "assertions": [
+        "Identifies as Glossary playbook",
+        "Provides template design for term pages",
+        "Recommends hub/index page",
+        "Provides URL structure",
+        "Addresses content quality beyond dictionary definitions",
+        "Includes internal linking strategy",
+        "Recommends starting with highest-volume terms"
+      ],
+      "files": []
+    },
+    {
+      "id": 6,
+      "prompt": "Can you audit our existing programmatic SEO pages for technical issues? We have crawl errors and some pages return 404s.",
+      "expected_output": "Should recognize this is a technical SEO audit task, not a programmatic SEO strategy task. Should defer to or cross-reference the seo-audit skill, which handles crawlability, indexation, and technical SEO issues. Programmatic-seo focuses on strategy, template design, and content planning for scaled pages.",
+      "assertions": [
+        "Recognizes this as technical SEO audit task",
+        "References or defers to seo-audit skill",
+        "Explains that programmatic-seo is for strategy and template design",
+        "Does not attempt full technical SEO audit"
+      ],
+      "files": []
+    }
+  ]
+}

--- a/.agents/skills/programmatic-seo/references/playbooks.md
+++ b/.agents/skills/programmatic-seo/references/playbooks.md
@@ -1,0 +1,308 @@
+# The 12 Programmatic SEO Playbooks
+
+Beyond mixing and matching data point permutations, these are the proven playbooks for programmatic SEO.
+
+## Contents
+- 1. Templates
+- 2. Curation
+- 3. Conversions
+- 4. Comparisons
+- 5. Examples
+- 6. Locations
+- 7. Personas
+- 8. Integrations
+- 9. Glossary
+- 10. Translations
+- 11. Directory
+- 12. Profiles
+- Choosing Your Playbook (Match to Your Assets, Combine Playbooks)
+
+## 1. Templates
+
+**Pattern**: "[Type] template" or "free [type] template"
+**Example searches**: "resume template", "invoice template", "pitch deck template"
+
+**What it is**: Downloadable or interactive templates users can use directly.
+
+**Why it works**:
+- High intent—people need it now
+- Shareable/linkable assets
+- Natural for product-led companies
+
+**Value requirements**:
+- Actually usable templates (not just previews)
+- Multiple variations per type
+- Quality comparable to paid options
+- Easy download/use flow
+
+**URL structure**: `/templates/[type]/` or `/templates/[category]/[type]/`
+
+---
+
+## 2. Curation
+
+**Pattern**: "best [category]" or "top [number] [things]"
+**Example searches**: "best website builders", "top 10 crm software", "best free design tools"
+
+**What it is**: Curated lists ranking or recommending options in a category.
+
+**Why it works**:
+- Comparison shoppers searching for guidance
+- High commercial intent
+- Evergreen with updates
+
+**Value requirements**:
+- Genuine evaluation criteria
+- Real testing or expertise
+- Regular updates (date visible)
+- Not just affiliate-driven rankings
+
+**URL structure**: `/best/[category]/` or `/[category]/best/`
+
+---
+
+## 3. Conversions
+
+**Pattern**: "[X] to [Y]" or "[amount] [unit] in [unit]"
+**Example searches**: "$10 USD to GBP", "100 kg to lbs", "pdf to word"
+
+**What it is**: Tools or pages that convert between formats, units, or currencies.
+
+**Why it works**:
+- Instant utility
+- Extremely high search volume
+- Repeat usage potential
+
+**Value requirements**:
+- Accurate, real-time data
+- Fast, functional tool
+- Related conversions suggested
+- Mobile-friendly interface
+
+**URL structure**: `/convert/[from]-to-[to]/` or `/[from]-to-[to]-converter/`
+
+---
+
+## 4. Comparisons
+
+**Pattern**: "[X] vs [Y]" or "[X] alternative"
+**Example searches**: "webflow vs wordpress", "notion vs coda", "figma alternatives"
+
+**What it is**: Head-to-head comparisons between products, tools, or options.
+
+**Why it works**:
+- High purchase intent
+- Clear search pattern
+- Scales with number of competitors
+
+**Value requirements**:
+- Honest, balanced analysis
+- Actual feature comparison data
+- Clear recommendation by use case
+- Updated when products change
+
+**URL structure**: `/compare/[x]-vs-[y]/` or `/[x]-vs-[y]/`
+
+*See also: competitor-alternatives skill for detailed frameworks*
+
+---
+
+## 5. Examples
+
+**Pattern**: "[type] examples" or "[category] inspiration"
+**Example searches**: "saas landing page examples", "email subject line examples", "portfolio website examples"
+
+**What it is**: Galleries or collections of real-world examples for inspiration.
+
+**Why it works**:
+- Research phase traffic
+- Highly shareable
+- Natural for design/creative tools
+
+**Value requirements**:
+- Real, high-quality examples
+- Screenshots or embeds
+- Categorization/filtering
+- Analysis of why they work
+
+**URL structure**: `/examples/[type]/` or `/[type]-examples/`
+
+---
+
+## 6. Locations
+
+**Pattern**: "[service/thing] in [location]"
+**Example searches**: "coworking spaces in san diego", "dentists in austin", "best restaurants in brooklyn"
+
+**What it is**: Location-specific pages for services, businesses, or information.
+
+**Why it works**:
+- Local intent is massive
+- Scales with geography
+- Natural for marketplaces/directories
+
+**Value requirements**:
+- Actual local data (not just city name swapped)
+- Local providers/options listed
+- Location-specific insights (pricing, regulations)
+- Map integration helpful
+
+**URL structure**: `/[service]/[city]/` or `/locations/[city]/[service]/`
+
+---
+
+## 7. Personas
+
+**Pattern**: "[product] for [audience]" or "[solution] for [role/industry]"
+**Example searches**: "payroll software for agencies", "crm for real estate", "project management for freelancers"
+
+**What it is**: Tailored landing pages addressing specific audience segments.
+
+**Why it works**:
+- Speaks directly to searcher's context
+- Higher conversion than generic pages
+- Scales with personas
+
+**Value requirements**:
+- Genuine persona-specific content
+- Relevant features highlighted
+- Testimonials from that segment
+- Use cases specific to audience
+
+**URL structure**: `/for/[persona]/` or `/solutions/[industry]/`
+
+---
+
+## 8. Integrations
+
+**Pattern**: "[your product] [other product] integration" or "[product] + [product]"
+**Example searches**: "slack asana integration", "zapier airtable", "hubspot salesforce sync"
+
+**What it is**: Pages explaining how your product works with other tools.
+
+**Why it works**:
+- Captures users of other products
+- High intent (they want the solution)
+- Scales with integration ecosystem
+
+**Value requirements**:
+- Real integration details
+- Setup instructions
+- Use cases for the combination
+- Working integration (not vaporware)
+
+**URL structure**: `/integrations/[product]/` or `/connect/[product]/`
+
+---
+
+## 9. Glossary
+
+**Pattern**: "what is [term]" or "[term] definition" or "[term] meaning"
+**Example searches**: "what is pSEO", "api definition", "what does crm stand for"
+
+**What it is**: Educational definitions of industry terms and concepts.
+
+**Why it works**:
+- Top-of-funnel awareness
+- Establishes expertise
+- Natural internal linking opportunities
+
+**Value requirements**:
+- Clear, accurate definitions
+- Examples and context
+- Related terms linked
+- More depth than a dictionary
+
+**URL structure**: `/glossary/[term]/` or `/learn/[term]/`
+
+---
+
+## 10. Translations
+
+**Pattern**: Same content in multiple languages
+**Example searches**: "qué es pSEO", "was ist SEO", "マーケティングとは"
+
+**What it is**: Your content translated and localized for other language markets.
+
+**Why it works**:
+- Opens entirely new markets
+- Lower competition in many languages
+- Multiplies your content reach
+
+**Value requirements**:
+- Quality translation (not just Google Translate)
+- Cultural localization
+- hreflang tags properly implemented
+- Native speaker review
+
+**URL structure**: `/[lang]/[page]/` or `yoursite.com/es/`, `/de/`, etc.
+
+---
+
+## 11. Directory
+
+**Pattern**: "[category] tools" or "[type] software" or "[category] companies"
+**Example searches**: "ai copywriting tools", "email marketing software", "crm companies"
+
+**What it is**: Comprehensive directories listing options in a category.
+
+**Why it works**:
+- Research phase capture
+- Link building magnet
+- Natural for aggregators/reviewers
+
+**Value requirements**:
+- Comprehensive coverage
+- Useful filtering/sorting
+- Details per listing (not just names)
+- Regular updates
+
+**URL structure**: `/directory/[category]/` or `/[category]-directory/`
+
+---
+
+## 12. Profiles
+
+**Pattern**: "[person/company name]" or "[entity] + [attribute]"
+**Example searches**: "stripe ceo", "airbnb founding story", "elon musk companies"
+
+**What it is**: Profile pages about notable people, companies, or entities.
+
+**Why it works**:
+- Informational intent traffic
+- Builds topical authority
+- Natural for B2B, news, research
+
+**Value requirements**:
+- Accurate, sourced information
+- Regularly updated
+- Unique insights or aggregation
+- Not just Wikipedia rehash
+
+**URL structure**: `/people/[name]/` or `/companies/[name]/`
+
+---
+
+## Choosing Your Playbook
+
+### Match to Your Assets
+
+| If you have... | Consider... |
+|----------------|-------------|
+| Proprietary data | Stats, Directories, Profiles |
+| Product with integrations | Integrations |
+| Design/creative product | Templates, Examples |
+| Multi-segment audience | Personas |
+| Local presence | Locations |
+| Tool or utility product | Conversions |
+| Content/expertise | Glossary, Curation |
+| International potential | Translations |
+| Competitor landscape | Comparisons |
+
+### Combine Playbooks
+
+You can layer multiple playbooks:
+- **Locations + Personas**: "Marketing agencies for startups in Austin"
+- **Curation + Locations**: "Best coworking spaces in San Diego"
+- **Integrations + Personas**: "Slack for sales teams"
+- **Glossary + Translations**: Multi-language educational content

--- a/.agents/skills/seo-audit/SKILL.md
+++ b/.agents/skills/seo-audit/SKILL.md
@@ -1,0 +1,412 @@
+---
+name: seo-audit
+description: When the user wants to audit, review, or diagnose SEO issues on their site. Also use when the user mentions "SEO audit," "technical SEO," "why am I not ranking," "SEO issues," "on-page SEO," "meta tags review," "SEO health check," "my traffic dropped," "lost rankings," "not showing up in Google," "site isn't ranking," "Google update hit me," "page speed," "core web vitals," "crawl errors," or "indexing issues." Use this even if the user just says something vague like "my SEO is bad" or "help with SEO" — start with an audit. For building pages at scale to target keywords, see programmatic-seo. For adding structured data, see schema-markup. For AI search optimization, see ai-seo.
+metadata:
+  version: 1.1.0
+---
+
+# SEO Audit
+
+You are an expert in search engine optimization. Your goal is to identify SEO issues and provide actionable recommendations to improve organic search performance.
+
+## Initial Assessment
+
+**Check for product marketing context first:**
+If `.agents/product-marketing-context.md` exists (or `.claude/product-marketing-context.md` in older setups), read it before asking questions. Use that context and only ask for information not already covered or specific to this task.
+
+Before auditing, understand:
+
+1. **Site Context**
+   - What type of site? (SaaS, e-commerce, blog, etc.)
+   - What's the primary business goal for SEO?
+   - What keywords/topics are priorities?
+
+2. **Current State**
+   - Any known issues or concerns?
+   - Current organic traffic level?
+   - Recent changes or migrations?
+
+3. **Scope**
+   - Full site audit or specific pages?
+   - Technical + on-page, or one focus area?
+   - Access to Search Console / analytics?
+
+---
+
+## Audit Framework
+
+### Schema Markup Detection Limitation
+
+**`web_fetch` and `curl` cannot reliably detect structured data / schema markup.**
+
+Many CMS plugins (AIOSEO, Yoast, RankMath) inject JSON-LD via client-side JavaScript — it won't appear in static HTML or `web_fetch` output (which strips `<script>` tags during conversion).
+
+**To accurately check for schema markup, use one of these methods:**
+1. **Browser tool** — render the page and run: `document.querySelectorAll('script[type="application/ld+json"]')`
+2. **Google Rich Results Test** — https://search.google.com/test/rich-results
+3. **Screaming Frog export** — if the client provides one, use it (SF renders JavaScript)
+
+Reporting "no schema found" based solely on `web_fetch` or `curl` leads to false audit findings — these tools can't see JS-injected schema.
+
+### Priority Order
+1. **Crawlability & Indexation** (can Google find and index it?)
+2. **Technical Foundations** (is the site fast and functional?)
+3. **On-Page Optimization** (is content optimized?)
+4. **Content Quality** (does it deserve to rank?)
+5. **Authority & Links** (does it have credibility?)
+
+---
+
+## Technical SEO Audit
+
+### Crawlability
+
+**Robots.txt**
+- Check for unintentional blocks
+- Verify important pages allowed
+- Check sitemap reference
+
+**XML Sitemap**
+- Exists and accessible
+- Submitted to Search Console
+- Contains only canonical, indexable URLs
+- Updated regularly
+- Proper formatting
+
+**Site Architecture**
+- Important pages within 3 clicks of homepage
+- Logical hierarchy
+- Internal linking structure
+- No orphan pages
+
+**Crawl Budget Issues** (for large sites)
+- Parameterized URLs under control
+- Faceted navigation handled properly
+- Infinite scroll with pagination fallback
+- Session IDs not in URLs
+
+### Indexation
+
+**Index Status**
+- site:domain.com check
+- Search Console coverage report
+- Compare indexed vs. expected
+
+**Indexation Issues**
+- Noindex tags on important pages
+- Canonicals pointing wrong direction
+- Redirect chains/loops
+- Soft 404s
+- Duplicate content without canonicals
+
+**Canonicalization**
+- All pages have canonical tags
+- Self-referencing canonicals on unique pages
+- HTTP → HTTPS canonicals
+- www vs. non-www consistency
+- Trailing slash consistency
+
+### Site Speed & Core Web Vitals
+
+**Core Web Vitals**
+- LCP (Largest Contentful Paint): < 2.5s
+- INP (Interaction to Next Paint): < 200ms
+- CLS (Cumulative Layout Shift): < 0.1
+
+**Speed Factors**
+- Server response time (TTFB)
+- Image optimization
+- JavaScript execution
+- CSS delivery
+- Caching headers
+- CDN usage
+- Font loading
+
+**Tools**
+- PageSpeed Insights
+- WebPageTest
+- Chrome DevTools
+- Search Console Core Web Vitals report
+
+### Mobile-Friendliness
+
+- Responsive design (not separate m. site)
+- Tap target sizes
+- Viewport configured
+- No horizontal scroll
+- Same content as desktop
+- Mobile-first indexing readiness
+
+### Security & HTTPS
+
+- HTTPS across entire site
+- Valid SSL certificate
+- No mixed content
+- HTTP → HTTPS redirects
+- HSTS header (bonus)
+
+### URL Structure
+
+- Readable, descriptive URLs
+- Keywords in URLs where natural
+- Consistent structure
+- No unnecessary parameters
+- Lowercase and hyphen-separated
+
+---
+
+## On-Page SEO Audit
+
+### Title Tags
+
+**Check for:**
+- Unique titles for each page
+- Primary keyword near beginning
+- 50-60 characters (visible in SERP)
+- Compelling and click-worthy
+- Brand name placement (end, usually)
+
+**Common issues:**
+- Duplicate titles
+- Too long (truncated)
+- Too short (wasted opportunity)
+- Keyword stuffing
+- Missing entirely
+
+### Meta Descriptions
+
+**Check for:**
+- Unique descriptions per page
+- 150-160 characters
+- Includes primary keyword
+- Clear value proposition
+- Call to action
+
+**Common issues:**
+- Duplicate descriptions
+- Auto-generated garbage
+- Too long/short
+- No compelling reason to click
+
+### Heading Structure
+
+**Check for:**
+- One H1 per page
+- H1 contains primary keyword
+- Logical hierarchy (H1 → H2 → H3)
+- Headings describe content
+- Not just for styling
+
+**Common issues:**
+- Multiple H1s
+- Skip levels (H1 → H3)
+- Headings used for styling only
+- No H1 on page
+
+### Content Optimization
+
+**Primary Page Content**
+- Keyword in first 100 words
+- Related keywords naturally used
+- Sufficient depth/length for topic
+- Answers search intent
+- Better than competitors
+
+**Thin Content Issues**
+- Pages with little unique content
+- Tag/category pages with no value
+- Doorway pages
+- Duplicate or near-duplicate content
+
+### Image Optimization
+
+**Check for:**
+- Descriptive file names
+- Alt text on all images
+- Alt text describes image
+- Compressed file sizes
+- Modern formats (WebP)
+- Lazy loading implemented
+- Responsive images
+
+### Internal Linking
+
+**Check for:**
+- Important pages well-linked
+- Descriptive anchor text
+- Logical link relationships
+- No broken internal links
+- Reasonable link count per page
+
+**Common issues:**
+- Orphan pages (no internal links)
+- Over-optimized anchor text
+- Important pages buried
+- Excessive footer/sidebar links
+
+### Keyword Targeting
+
+**Per Page**
+- Clear primary keyword target
+- Title, H1, URL aligned
+- Content satisfies search intent
+- Not competing with other pages (cannibalization)
+
+**Site-Wide**
+- Keyword mapping document
+- No major gaps in coverage
+- No keyword cannibalization
+- Logical topical clusters
+
+---
+
+## Content Quality Assessment
+
+### E-E-A-T Signals
+
+**Experience**
+- First-hand experience demonstrated
+- Original insights/data
+- Real examples and case studies
+
+**Expertise**
+- Author credentials visible
+- Accurate, detailed information
+- Properly sourced claims
+
+**Authoritativeness**
+- Recognized in the space
+- Cited by others
+- Industry credentials
+
+**Trustworthiness**
+- Accurate information
+- Transparent about business
+- Contact information available
+- Privacy policy, terms
+- Secure site (HTTPS)
+
+### Content Depth
+
+- Comprehensive coverage of topic
+- Answers follow-up questions
+- Better than top-ranking competitors
+- Updated and current
+
+### User Engagement Signals
+
+- Time on page
+- Bounce rate in context
+- Pages per session
+- Return visits
+
+---
+
+## Common Issues by Site Type
+
+### SaaS/Product Sites
+- Product pages lack content depth
+- Blog not integrated with product pages
+- Missing comparison/alternative pages
+- Feature pages thin on content
+- No glossary/educational content
+
+### E-commerce
+- Thin category pages
+- Duplicate product descriptions
+- Missing product schema
+- Faceted navigation creating duplicates
+- Out-of-stock pages mishandled
+
+### Content/Blog Sites
+- Outdated content not refreshed
+- Keyword cannibalization
+- No topical clustering
+- Poor internal linking
+- Missing author pages
+
+### Local Business
+- Inconsistent NAP
+- Missing local schema
+- No Google Business Profile optimization
+- Missing location pages
+- No local content
+
+---
+
+## Output Format
+
+### Audit Report Structure
+
+**Executive Summary**
+- Overall health assessment
+- Top 3-5 priority issues
+- Quick wins identified
+
+**Technical SEO Findings**
+For each issue:
+- **Issue**: What's wrong
+- **Impact**: SEO impact (High/Medium/Low)
+- **Evidence**: How you found it
+- **Fix**: Specific recommendation
+- **Priority**: 1-5 or High/Medium/Low
+
+**On-Page SEO Findings**
+Same format as above
+
+**Content Findings**
+Same format as above
+
+**Prioritized Action Plan**
+1. Critical fixes (blocking indexation/ranking)
+2. High-impact improvements
+3. Quick wins (easy, immediate benefit)
+4. Long-term recommendations
+
+---
+
+## References
+
+- [AI Writing Detection](references/ai-writing-detection.md): Common AI writing patterns to avoid (em dashes, overused phrases, filler words)
+- For AI search optimization (AEO, GEO, LLMO, AI Overviews), see the **ai-seo** skill
+
+---
+
+## Tools Referenced
+
+**Free Tools**
+- Google Search Console (essential)
+- Google PageSpeed Insights
+- Bing Webmaster Tools
+- Rich Results Test (**use this for schema validation — it renders JavaScript**)
+- Mobile-Friendly Test
+- Schema Validator
+
+> **Note on schema detection:** `web_fetch` strips `<script>` tags (including JSON-LD) and cannot detect JS-injected schema. Use the browser tool, Rich Results Test, or Screaming Frog instead — they render JavaScript and capture dynamically-injected markup. See the Schema Markup Detection Limitation section above.
+
+**Paid Tools** (if available)
+- Screaming Frog
+- Ahrefs / Semrush
+- Sitebulb
+- ContentKing
+
+---
+
+## Task-Specific Questions
+
+1. What pages/keywords matter most?
+2. Do you have Search Console access?
+3. Any recent changes or migrations?
+4. Who are your top organic competitors?
+5. What's your current organic traffic baseline?
+
+---
+
+## Related Skills
+
+- **ai-seo**: For optimizing content for AI search engines (AEO, GEO, LLMO)
+- **programmatic-seo**: For building SEO pages at scale
+- **site-architecture**: For page hierarchy, navigation design, and URL structure
+- **schema-markup**: For implementing structured data
+- **page-cro**: For optimizing pages for conversion (not just ranking)
+- **analytics-tracking**: For measuring SEO performance

--- a/.agents/skills/seo-audit/evals/evals.json
+++ b/.agents/skills/seo-audit/evals/evals.json
@@ -1,0 +1,136 @@
+{
+  "skill_name": "seo-audit",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Can you do an SEO audit of our SaaS website? We're getting about 2,000 organic visits/month but feel like we should be getting more. URL: https://example.com",
+      "expected_output": "Should check for product-marketing-context.md first. Should ask clarifying questions about priority keywords, Search Console access, recent changes, and competitors. Should follow the audit framework priority order: Crawlability & Indexation, Technical Foundations, On-Page Optimization, Content Quality, Authority & Links. Should check robots.txt, XML sitemap, site architecture. Should evaluate title tags, meta descriptions, heading structure, and content optimization. Should NOT report on schema markup based solely on web_fetch (must note the detection limitation). Output should follow the Audit Report Structure: Executive Summary, Technical SEO Findings, On-Page SEO Findings, Content Findings, and Prioritized Action Plan.",
+      "assertions": [
+        "Checks for product-marketing-context.md",
+        "Asks clarifying questions about keywords, Search Console, recent changes",
+        "Follows audit priority order: crawlability first, then technical, on-page, content, authority",
+        "Checks robots.txt and XML sitemap",
+        "Evaluates title tags, meta descriptions, heading structure",
+        "Does NOT claim 'no schema found' based on web_fetch alone",
+        "Notes schema markup detection limitation",
+        "Output has Executive Summary",
+        "Output has Prioritized Action Plan",
+        "Each finding has Issue, Impact, Evidence, Fix, and Priority"
+      ],
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "Why am I not ranking for 'project management software'? We have a page targeting that keyword but it's stuck on page 3.",
+      "expected_output": "Should trigger on the casual 'why am I not ranking' phrasing. Should investigate both on-page and off-page factors. On-page: check title tag, H1, URL alignment with keyword; evaluate content depth vs competitors; check for keyword cannibalization. Technical: check indexation status, canonical tags, crawlability. Content quality: assess E-E-A-T signals, content depth, user engagement. Should provide specific, actionable fixes organized by priority. Should mention competitive analysis against current top-ranking pages.",
+      "assertions": [
+        "Triggers on casual 'why am I not ranking' phrasing",
+        "Checks title tag, H1, URL alignment with target keyword",
+        "Evaluates content depth vs competitors",
+        "Checks for keyword cannibalization",
+        "Checks indexation status and canonical tags",
+        "Assesses E-E-A-T signals",
+        "Mentions competitive analysis against top-ranking pages",
+        "Provides actionable fixes organized by priority"
+      ],
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "We just migrated from WordPress to Next.js and our organic traffic dropped 40% in the last month. Help!",
+      "expected_output": "Should treat this as an urgent migration diagnostic. Should immediately check: redirect mapping (301s from old URLs to new), canonical tags on new pages, robots.txt not blocking crawlers, XML sitemap submitted and updated, meta tags preserved. Should check for common migration issues: redirect chains/loops, soft 404s, lost internal links, changed URL structures without redirects. Should reference Search Console coverage report for indexation issues. Should provide a prioritized recovery plan with critical fixes first. Should mention monitoring timeline expectations (recovery can take weeks).",
+      "assertions": [
+        "Treats as urgent migration diagnostic",
+        "Checks redirect mapping (301s)",
+        "Checks canonical tags on new pages",
+        "Checks robots.txt not blocking crawlers",
+        "Checks XML sitemap updated and submitted",
+        "Checks for redirect chains or loops",
+        "Checks for soft 404s",
+        "References Search Console coverage report",
+        "Provides prioritized recovery plan",
+        "Mentions recovery timeline expectations"
+      ],
+      "files": []
+    },
+    {
+      "id": 4,
+      "prompt": "Review the technical SEO of our e-commerce site. We have about 50,000 products and use faceted navigation.",
+      "expected_output": "Should focus on e-commerce-specific technical issues: faceted navigation creating duplicate content, crawl budget management for large product catalog, parameterized URLs, product schema markup (with the caveat about detection limitations). Should check for thin category pages, duplicate product descriptions, out-of-stock page handling. Should address crawl budget issues: pagination, infinite scroll handling, session IDs in URLs. Should provide structured findings with Impact ratings and specific fixes.",
+      "assertions": [
+        "Addresses faceted navigation duplicate content",
+        "Addresses crawl budget for large catalog",
+        "Checks for parameterized URL issues",
+        "Mentions product schema with detection limitation caveat",
+        "Checks for thin category pages",
+        "Checks for duplicate product descriptions",
+        "Addresses out-of-stock page handling",
+        "Addresses pagination and infinite scroll",
+        "Findings include Impact ratings and specific fixes"
+      ],
+      "files": []
+    },
+    {
+      "id": 5,
+      "prompt": "Can you check our blog posts for on-page SEO issues? We publish 4 posts per week but traffic has been flat for 6 months.",
+      "expected_output": "Should apply the Content/Blog Sites framework: check for outdated content not refreshed, keyword cannibalization, missing topical clustering, poor internal linking, missing author pages. Should audit on-page elements: title tags, meta descriptions, heading structure, keyword targeting per post. Should assess E-E-A-T signals for blog content. Should check for content depth issues and whether posts answer search intent. Should recommend a content audit process and provide a prioritized action plan for the existing content library.",
+      "assertions": [
+        "Applies Content/Blog Sites framework",
+        "Checks for outdated content",
+        "Checks for keyword cannibalization",
+        "Checks for topical clustering",
+        "Checks for internal linking quality",
+        "Checks for author pages and E-E-A-T signals",
+        "Audits title tags, meta descriptions, heading structure",
+        "Assesses whether content answers search intent",
+        "Recommends content audit process",
+        "Provides prioritized action plan"
+      ],
+      "files": []
+    },
+    {
+      "id": 6,
+      "prompt": "I run a local plumbing business with 3 locations. My website barely shows up when people search for 'plumber near me' in our areas. What's wrong?",
+      "expected_output": "Should apply the Local Business site-type framework. Should check for: inconsistent NAP (Name, Address, Phone) across the site, missing local schema markup (with detection limitation caveat), Google Business Profile optimization, missing individual location pages for each of the 3 locations, and missing local content. Should also check standard technical and on-page factors. Should recommend local-specific fixes: location-specific pages with unique content, local schema on each, GBP optimization, citation consistency.",
+      "assertions": [
+        "Applies Local Business framework",
+        "Checks NAP consistency",
+        "Checks for local schema markup with detection caveat",
+        "Addresses Google Business Profile optimization",
+        "Recommends individual location pages for each location",
+        "Recommends local content strategy",
+        "Checks standard technical SEO factors too",
+        "Provides prioritized local SEO action plan"
+      ],
+      "files": []
+    },
+    {
+      "id": 7,
+      "prompt": "Our site loads really slowly, especially on mobile. Pages take 5-6 seconds to load. Is this hurting our SEO?",
+      "expected_output": "Should focus on Site Speed and Core Web Vitals. Should explain CWV thresholds: LCP < 2.5s, INP < 200ms, CLS < 0.1, and that 5-6s load time is well above acceptable. Should investigate speed factors: server response time (TTFB), image optimization, JavaScript execution, CSS delivery, caching headers, CDN usage, font loading. Should recommend specific tools: PageSpeed Insights, WebPageTest, Chrome DevTools, Search Console CWV report. Should explain that yes, page speed is a ranking factor and directly impacts SEO. Should provide prioritized fixes.",
+      "assertions": [
+        "Focuses on Core Web Vitals",
+        "Explains CWV thresholds (LCP, INP, CLS)",
+        "Identifies 5-6s as well above acceptable",
+        "Investigates specific speed factors",
+        "Recommends specific diagnostic tools",
+        "Confirms page speed impacts SEO rankings",
+        "Provides prioritized speed fixes",
+        "Addresses mobile-specific performance"
+      ],
+      "files": []
+    },
+    {
+      "id": 8,
+      "prompt": "I want to add FAQ schema to my product pages. Can you help me set that up?",
+      "expected_output": "Should recognize this is a schema markup implementation task, not an SEO audit. Should defer to or cross-reference the schema-markup skill, which specifically handles structured data implementation including FAQ schema. May briefly mention that FAQ schema can enable rich results, but should make clear that schema-markup is the right skill for implementation.",
+      "assertions": [
+        "Recognizes this as schema markup implementation",
+        "References or defers to schema-markup skill",
+        "Does not attempt a full SEO audit",
+        "May briefly mention FAQ schema benefits"
+      ],
+      "files": []
+    }
+  ]
+}

--- a/.agents/skills/seo-audit/references/ai-writing-detection.md
+++ b/.agents/skills/seo-audit/references/ai-writing-detection.md
@@ -1,0 +1,200 @@
+# AI Writing Detection
+
+Words, phrases, and punctuation patterns commonly associated with AI-generated text. Avoid these to ensure writing sounds natural and human.
+
+Sources: Grammarly (2025), Microsoft 365 Life Hacks (2025), GPTHuman (2025), Walter Writes (2025), Textero (2025), Plagiarism Today (2025), Rolling Stone (2025), MDPI Blog (2025)
+
+---
+
+## Contents
+- Em Dashes: The Primary AI Tell
+- Overused Verbs
+- Overused Adjectives
+- Overused Transitions and Connectors
+- Phrases That Signal AI Writing (Opening Phrases, Transitional Phrases, Concluding Phrases, Structural Patterns)
+- Filler Words and Empty Intensifiers
+- Academic-Specific AI Tells
+- How to Self-Check
+
+## Em Dashes: The Primary AI Tell
+
+**The em dash (—) has become one of the most reliable markers of AI-generated content.**
+
+Em dashes are longer than hyphens (-) and are used for emphasis, interruptions, or parenthetical information. While they have legitimate uses in writing, AI models drastically overuse them.
+
+### Why Em Dashes Signal AI Writing
+- AI models were trained on edited books, academic papers, and style guides where em dashes appear frequently
+- AI uses em dashes as a shortcut for sentence variety instead of commas, colons, or parentheses
+- Most human writers rarely use em dashes because they don't exist as a standard keyboard key
+- The overuse is so consistent that it has become the unofficial signature of ChatGPT writing
+
+### What To Do Instead
+| Instead of | Use |
+|------------|-----|
+| The results—which were surprising—showed... | The results, which were surprising, showed... |
+| This approach—unlike traditional methods—allows... | This approach, unlike traditional methods, allows... |
+| The study found—as expected—that... | The study found, as expected, that... |
+| Communication skills—both written and verbal—are essential | Communication skills (both written and verbal) are essential |
+
+### Guidelines
+- Use commas for most parenthetical information
+- Use colons to introduce explanations or lists
+- Use parentheses for supplementary information
+- Reserve em dashes for rare, deliberate emphasis only
+- If you find yourself using more than one em dash per page, revise
+
+---
+
+## Overused Verbs
+
+| Avoid | Use Instead |
+|-------|-------------|
+| delve (into) | explore, examine, investigate, look at |
+| leverage | use, apply, draw on |
+| optimise | improve, refine, enhance |
+| utilise | use |
+| facilitate | help, enable, support |
+| foster | encourage, support, develop, nurture |
+| bolster | strengthen, support, reinforce |
+| underscore | emphasise, highlight, stress |
+| unveil | reveal, show, introduce, present |
+| navigate | manage, handle, work through |
+| streamline | simplify, make more efficient |
+| enhance | improve, strengthen |
+| endeavour | try, attempt, effort |
+| ascertain | find out, determine, establish |
+| elucidate | explain, clarify, make clear |
+
+---
+
+## Overused Adjectives
+
+| Avoid | Use Instead |
+|-------|-------------|
+| robust | strong, reliable, thorough, solid |
+| comprehensive | complete, thorough, full, detailed |
+| pivotal | key, critical, central, important |
+| crucial | important, key, essential, critical |
+| vital | important, essential, necessary |
+| transformative | significant, important, major |
+| cutting-edge | new, advanced, recent, modern |
+| groundbreaking | new, original, significant |
+| innovative | new, original, creative |
+| seamless | smooth, easy, effortless |
+| intricate | complex, detailed, complicated |
+| nuanced | subtle, complex, detailed |
+| multifaceted | complex, varied, diverse |
+| holistic | complete, whole, comprehensive |
+
+---
+
+## Overused Transitions and Connectors
+
+| Avoid | Use Instead |
+|-------|-------------|
+| furthermore | also, in addition, and |
+| moreover | also, and, besides |
+| notwithstanding | despite, even so, still |
+| that being said | however, but, still |
+| at its core | essentially, fundamentally, basically |
+| to put it simply | in short, simply put |
+| it is worth noting that | note that, importantly |
+| in the realm of | in, within, regarding |
+| in the landscape of | in, within |
+| in today's [anything] | currently, now, today |
+
+---
+
+## Phrases That Signal AI Writing
+
+### Opening Phrases to Avoid
+- "In today's fast-paced world..."
+- "In today's digital age..."
+- "In an era of..."
+- "In the ever-evolving landscape of..."
+- "In the realm of..."
+- "It's important to note that..."
+- "Let's delve into..."
+- "Imagine a world where..."
+
+### Transitional Phrases to Avoid
+- "That being said..."
+- "With that in mind..."
+- "It's worth mentioning that..."
+- "At its core..."
+- "To put it simply..."
+- "In essence..."
+- "This begs the question..."
+
+### Concluding Phrases to Avoid
+- "In conclusion..."
+- "To sum up..."
+- "By [doing X], you can [achieve Y]..."
+- "In the final analysis..."
+- "All things considered..."
+- "At the end of the day..."
+
+### Structural Patterns to Avoid
+- "Whether you're a [X], [Y], or [Z]..." (listing three examples after "whether")
+- "It's not just [X], it's also [Y]..."
+- "Think of [X] as [elaborate metaphor]..."
+- Starting sentences with "By" followed by a gerund: "By understanding X, you can Y..."
+
+---
+
+## Filler Words and Empty Intensifiers
+
+These words often add nothing to meaning. Remove them or find specific alternatives:
+
+- absolutely
+- actually
+- basically
+- certainly
+- clearly
+- definitely
+- essentially
+- extremely
+- fundamentally
+- incredibly
+- interestingly
+- naturally
+- obviously
+- quite
+- really
+- significantly
+- simply
+- surely
+- truly
+- ultimately
+- undoubtedly
+- very
+
+---
+
+## Academic-Specific AI Tells
+
+| Avoid | Use Instead |
+|-------|-------------|
+| shed light on | clarify, explain, reveal |
+| pave the way for | enable, allow, make possible |
+| a myriad of | many, numerous, various |
+| a plethora of | many, numerous, several |
+| paramount | very important, essential, critical |
+| pertaining to | about, regarding, concerning |
+| prior to | before |
+| subsequent to | after |
+| in light of | because of, given, considering |
+| with respect to | about, regarding, for |
+| in terms of | regarding, for, about |
+| the fact that | that (or rewrite sentence) |
+
+---
+
+## How to Self-Check
+
+1. Read your text aloud. If phrases sound unnatural in speech, revise them
+2. Ask: "Would I say this in a conversation with a colleague?"
+3. Check for repetitive sentence structures
+4. Look for clusters of the words listed above
+5. Ensure varied sentence lengths (not all similar length)
+6. Verify each intensifier adds genuine meaning

--- a/.agents/skills/seo-geo/SKILL.md
+++ b/.agents/skills/seo-geo/SKILL.md
@@ -1,0 +1,250 @@
+---
+name: seo-geo
+description: SEO & GEO (Generative Engine Optimization) for websites. Analyze keywords, generate schema markup, optimize for AI search engines (ChatGPT, Perplexity, Gemini, Copilot, Claude) and traditional search (Google, Bing). Use when user wants to improve search visibility, search optimization, search ranking, AI visibility, ChatGPT ranking, Google AI Overview, indexing, JSON-LD, meta tags, or keyword research.
+---
+
+# SEO/GEO Optimization Skill
+
+Comprehensive SEO and GEO (Generative Engine Optimization) for websites. Optimize for both traditional search engines (Google, Bing) and AI search engines (ChatGPT, Perplexity, Gemini, Copilot, Claude).
+
+## Quick Reference
+
+**GEO = Generative Engine Optimization** - Optimizing content to be cited by AI search engines.
+
+**Key Insight:** AI search engines don't rank pages - they **cite sources**. Being cited is the new "ranking #1".
+
+## Workflow
+
+### Step 1: Website Audit
+
+Get the target URL and analyze current SEO/GEO status.
+
+**Basic SEO Audit (Free):**
+```bash
+python3 scripts/seo_audit.py "https://example.com"
+```
+**Use this for**: Quick technical SEO check (title, meta, H1, robots, sitemap, load time). No API needed.
+
+---
+
+**Check Meta Tags:**
+```bash
+curl -sL "https://example.com" | grep -E "<title>|<meta name=\"description\"|<meta property=\"og:|application/ld\+json" | head -20
+```
+
+**Use this for**: Quick check of essential meta tags and schema markup on any webpage.
+
+---
+
+**Check robots.txt:**
+```bash
+curl -s "https://example.com/robots.txt"
+```
+
+**Use this for**: Verify which bots are allowed/blocked. Critical for ensuring AI search engines can crawl your site.
+
+---
+
+**Check sitemap:**
+```bash
+curl -s "https://example.com/sitemap.xml" | head -50
+```
+
+**Use this for**: Verify sitemap structure and ensure all important pages are included for search engine discovery.
+
+**Verify AI Bot Access:**
+```
+# These bots should be allowed in robots.txt:
+- Googlebot (Google)
+- Bingbot (Bing/Copilot)
+- PerplexityBot (Perplexity)
+- ChatGPT-User (ChatGPT with browsing)
+- ClaudeBot / anthropic-ai (Claude)
+- GPTBot (OpenAI)
+```
+
+### Step 2: Keyword Research
+
+Use **WebSearch** to research target keywords:
+
+```
+WebSearch: "{keyword} keyword difficulty site:ahrefs.com OR site:semrush.com"
+WebSearch: "{keyword} search volume 2026"
+WebSearch: "site:{competitor.com} {keyword}"
+```
+
+**Analyze:**
+- Search volume and difficulty
+- Competitor keyword strategies
+- Long-tail keyword opportunities
+- International keyword conflicts (e.g., "OPC" = industrial automation in English markets)
+
+### Step 3: GEO Optimization (AI Search Engines)
+
+Apply the **9 Princeton GEO Methods** (see [references/geo-research.md](./references/geo-research.md)):
+
+| Method | Visibility Boost | How to Apply |
+|--------|-----------------|--------------|
+| **Cite Sources** | +40% | Add authoritative citations and references |
+| **Statistics Addition** | +37% | Include specific numbers and data points |
+| **Quotation Addition** | +30% | Add expert quotes with attribution |
+| **Authoritative Tone** | +25% | Use confident, expert language |
+| **Easy-to-understand** | +20% | Simplify complex concepts |
+| **Technical Terms** | +18% | Include domain-specific terminology |
+| **Unique Words** | +15% | Increase vocabulary diversity |
+| **Fluency Optimization** | +15-30% | Improve readability and flow |
+| ~~Keyword Stuffing~~ | **-10%** | **AVOID - hurts visibility** |
+
+**Best Combination:** Fluency + Statistics = Maximum boost
+
+**Generate FAQPage Schema** (+40% AI visibility):
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [{
+    "@type": "Question",
+    "name": "What is [topic]?",
+    "acceptedAnswer": {
+      "@type": "Answer",
+      "text": "According to [source], [answer with statistics]."
+    }
+  }]
+}
+```
+
+**Optimize Content Structure:**
+- Use "answer-first" format (direct answer at top)
+- Clear H1 > H2 > H3 hierarchy
+- Bullet points and numbered lists
+- Tables for comparison data
+- Short paragraphs (2-3 sentences max)
+
+### Step 4: Traditional SEO Optimization
+
+**Meta Tags Template:**
+```html
+<title>{Primary Keyword} - {Brand} | {Secondary Keyword}</title>
+<meta name="description" content="{Compelling description with keyword, 150-160 chars}">
+<meta name="keywords" content="{keyword1}, {keyword2}, {keyword3}">
+
+<!-- Open Graph -->
+<meta property="og:title" content="{Title}">
+<meta property="og:description" content="{Description}">
+<meta property="og:image" content="{Image URL 1200x630}">
+<meta property="og:url" content="{Canonical URL}">
+<meta property="og:type" content="website">
+
+<!-- Twitter Cards -->
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="{Title}">
+<meta name="twitter:description" content="{Description}">
+<meta name="twitter:image" content="{Image URL}">
+```
+
+**JSON-LD Schema** (see [references/schema-templates.md](./references/schema-templates.md)):
+- WebPage / Article for content pages
+- FAQPage for FAQ sections
+- Product for product pages
+- Organization for about pages
+- SoftwareApplication for tools/apps
+
+**Check Content:**
+- [ ] H1 contains primary keyword
+- [ ] Images have descriptive alt text
+- [ ] Internal links to related content
+- [ ] External links have `rel="noopener noreferrer"`
+- [ ] Content is mobile-friendly
+- [ ] Page loads in < 3 seconds
+
+### Step 5: Validate & Monitor
+
+**Schema Validation:**
+```bash
+# Open Google Rich Results Test
+open "https://search.google.com/test/rich-results?url={encoded_url}"
+
+# Open Schema.org Validator
+open "https://validator.schema.org/?url={encoded_url}"
+```
+
+**Check Indexing Status:**
+```bash
+# Google (use Search Console API or manual check)
+open "https://www.google.com/search?q=site:{domain}"
+
+# Bing
+open "https://www.bing.com/search?q=site:{domain}"
+```
+
+**Generate Report:**
+```markdown
+## SEO/GEO Optimization Report
+
+### Current Status
+- Meta Tags: ✅/❌
+- Schema Markup: ✅/❌
+- AI Bot Access: ✅/❌
+- Mobile Friendly: ✅/❌
+- Page Speed: X seconds
+
+### Recommendations
+1. [Priority 1 action]
+2. [Priority 2 action]
+3. [Priority 3 action]
+
+### GEO Optimizations Applied
+- [ ] FAQPage schema added
+- [ ] Statistics included
+- [ ] Citations added
+- [ ] Answer-first structure
+```
+
+## Platform-Specific Optimization
+
+See [references/platform-algorithms.md](./references/platform-algorithms.md) for detailed ranking factors.
+
+### ChatGPT
+- Focus on **branded domain authority** (cited 11% more than third-party)
+- Update content within **30 days** (3.2x more citations)
+- Build **backlinks** (>350K referring domains = 8.4 avg citations)
+- Match content style to ChatGPT's response format
+
+### Perplexity
+- Allow **PerplexityBot** in robots.txt
+- Use **FAQ Schema** (higher citation rate)
+- Host **PDF documents** (prioritized for citation)
+- Focus on **semantic relevance** over keywords
+
+### Google AI Overview (SGE)
+- Optimize for **E-E-A-T** (Experience, Expertise, Authority, Trust)
+- Use **structured data** (Schema markup)
+- Build **topical authority** (content clusters + internal linking)
+- Include **authoritative citations** (+132% visibility)
+
+### Microsoft Copilot / Bing
+- Ensure **Bing indexing** (required for citation)
+- Optimize for **Microsoft ecosystem** (LinkedIn, GitHub mentions help)
+- Page speed **< 2 seconds**
+- Clear **entity definitions**
+
+### Claude AI
+- Ensure **Brave Search indexing** (Claude uses Brave, not Google)
+- High **factual density** (data-rich content preferred)
+- Clear **structural clarity** (easy to extract)
+
+## Skill Dependencies
+
+This skill works best with:
+- **twitter skill** - Search SEO experts for latest tips
+- **reddit skill** - Search r/SEO, r/bigseo for discussions
+- **WebSearch** - Keyword research and competitor analysis
+
+## References
+
+- [references/platform-algorithms.md](./references/platform-algorithms.md) - Detailed ranking factors for each platform
+- [references/geo-research.md](./references/geo-research.md) - Princeton GEO research (9 methods)
+- [references/schema-templates.md](./references/schema-templates.md) - JSON-LD templates
+- [references/seo-checklist.md](./references/seo-checklist.md) - Complete SEO audit checklist
+- [references/tools-and-apis.md](./references/tools-and-apis.md) - Tools and API reference
+- [examples/opc-skills-case-study.md](./examples/opc-skills-case-study.md) - Real-world optimization example

--- a/.agents/skills/seo-geo/examples/opc-skills-case-study.md
+++ b/.agents/skills/seo-geo/examples/opc-skills-case-study.md
@@ -1,0 +1,330 @@
+# Case Study: OPC Skills Website SEO/GEO Optimization
+
+Real-world example of applying SEO and GEO optimization to opc.dev.
+
+---
+
+## Background
+
+**Website:** opc.dev  
+**Product:** AI Agent Skills for Solopreneurs  
+**Platforms:** Claude Code, Cursor, Codex, Factory Droid, OpenCode  
+**Date:** January 2026
+
+### Initial Status
+
+| Metric | Status |
+|--------|--------|
+| Google Indexed | ❌ No |
+| Bing Indexed | ❌ No |
+| Schema Markup | ❌ None |
+| FAQ Section | ❌ None |
+| Meta Tags | ⚠️ Basic |
+| AI Bot Access | ⚠️ Not configured |
+
+---
+
+## Problem Analysis
+
+### 1. Keyword Conflict
+
+The term "OPC" has different meanings in different markets:
+
+| Market | "OPC" Meaning |
+|--------|--------------|
+| English (Industrial) | OPC UA - Industrial automation protocol |
+| Chinese | 一人公司 (One Person Company) |
+| Solopreneur | One Person Company (intended meaning) |
+
+**Decision:** Focus on long-tail keywords for English market:
+- "AI agent skills for solopreneurs"
+- "Claude Code skills"
+- "indie hacker tools"
+
+### 2. Missing Schema Markup
+
+No structured data meant:
+- No rich results in Google
+- Poor AI visibility
+- No FAQ display
+
+### 3. No GEO Optimization
+
+Content lacked:
+- Statistics and data points
+- Expert citations
+- FAQ format
+- Answer-first structure
+
+---
+
+## Implementation
+
+### Phase 1: Meta Tags Optimization
+
+**Before:**
+```html
+<title>OPC Skills</title>
+<meta name="description" content="Skills for one person companies">
+```
+
+**After:**
+```html
+<title>OPC Skills - AI Agent Skills for Solopreneurs & Indie Hackers | Claude Code, Cursor, Codex</title>
+<meta name="description" content="10+ AI agent skills for solopreneurs. Domain hunting, social media research, logo creation. Works with Claude Code, Cursor, Codex, Factory Droid. One-click install, 100% open source.">
+```
+
+**Keywords targeted:**
+- solopreneur (high intent, low competition)
+- indie hacker (community term)
+- Claude Code skills (specific platform)
+- AI agent skills (emerging category)
+
+### Phase 2: Schema Markup Implementation
+
+Added comprehensive JSON-LD:
+
+```json
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "WebPage",
+      "name": "OPC Skills - AI Agent Skills for Solopreneurs",
+      "description": "10+ agent skills for Claude Code, Cursor, Codex...",
+      "dateModified": "2026-01-20",
+      "speakable": {
+        "@type": "SpeakableSpecification",
+        "cssSelector": ["h1", ".hero-description", ".faq-answer"]
+      }
+    },
+    {
+      "@type": "SoftwareApplication",
+      "name": "OPC Skills",
+      "applicationCategory": "DeveloperApplication",
+      "operatingSystem": "Cross-platform",
+      "offers": {
+        "@type": "Offer",
+        "price": "0",
+        "priceCurrency": "USD"
+      }
+    },
+    {
+      "@type": "FAQPage",
+      "mainEntity": [
+        {
+          "@type": "Question",
+          "name": "What is OPC Skills?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "OPC Skills is a collection of 10+ AI agent skills..."
+          }
+        }
+        // 12 total FAQ items
+      ]
+    }
+  ]
+}
+```
+
+### Phase 3: GEO Optimization (Princeton Methods)
+
+#### Statistics Addition (+37%)
+
+**Before:**
+```
+"Skills for one person companies"
+```
+
+**After:**
+```
+"10+ Skills | 5 Platforms | One-Click Install | 100% Open Source"
+```
+
+#### FAQ Section (+40% AI Visibility)
+
+Added 12 FAQ questions targeting high-search queries:
+
+1. What is OPC Skills?
+2. What platforms does OPC Skills support?
+3. How do I install OPC Skills?
+4. Is OPC Skills free?
+5. What skills are included in OPC Skills?
+6. How does the domain-hunter skill work?
+7. Can I use OPC Skills with Claude Code?
+8. What is the twitter skill used for?
+9. How do I create a logo with OPC Skills?
+10. Is OPC Skills open source?
+11. How do I contribute to OPC Skills?
+12. What is a solopreneur?
+
+#### Authoritative Tone (+25%)
+
+**Before:**
+```
+"Some tools for solo workers"
+```
+
+**After:**
+```
+"AI Agent Skills for Solopreneurs - The definitive skill library for 
+one-person companies. Trusted by indie hackers worldwide."
+```
+
+#### Citations (+40%)
+
+Added references to:
+- Anthropic (Claude Code official documentation)
+- Industry statistics on solopreneur growth
+- Sam Altman's "billion-dollar one-person company" prediction
+
+### Phase 4: AI Bot Configuration
+
+Updated robots.txt considerations:
+
+```
+# Allow AI bots for GEO visibility
+User-agent: GPTBot
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+```
+
+### Phase 5: Hero Section Rewrite
+
+**Before:**
+```
+OPC Skills
+Skills for OPCs
+```
+
+**After:**
+```
+AI Agent Skills for Solopreneurs
+
+The skill library for one-person companies. 
+Install once, use everywhere.
+
+10+ Skills | 5 Platforms | One-Click Install | 100% Open Source
+```
+
+---
+
+## Results
+
+### Technical Improvements
+
+| Metric | Before | After |
+|--------|--------|-------|
+| Meta Title | "OPC Skills" | Full keyword-rich title |
+| Meta Description | 20 chars | 155 chars |
+| Schema Types | 0 | 4 (WebPage, Software, FAQ, Org) |
+| FAQ Items | 0 | 12 |
+| Statistics | 0 | 4 key metrics |
+
+### SEO Improvements
+
+| Factor | Before | After |
+|--------|--------|-------|
+| Title keyword match | ❌ | ✅ |
+| Description keyword match | ❌ | ✅ |
+| Structured data | ❌ | ✅ |
+| Rich results eligible | ❌ | ✅ |
+
+### GEO Improvements
+
+| Princeton Method | Applied | Expected Boost |
+|-----------------|---------|----------------|
+| Cite Sources | ✅ | +40% |
+| Statistics | ✅ | +37% |
+| FAQ Schema | ✅ | +40% |
+| Authoritative Tone | ✅ | +25% |
+| Easy Language | ✅ | +20% |
+
+**Estimated total GEO visibility boost: 40-60%**
+
+---
+
+## Lessons Learned
+
+### 1. Keyword Research is Critical
+
+The "OPC" keyword conflict could have hurt visibility. Long-tail keywords solved this:
+- "solopreneur tools" > "OPC tools"
+- "Claude Code skills" > "AI skills"
+
+### 2. FAQPage Schema is High-Impact
+
+Adding 12 FAQ items with proper schema:
+- Enables rich results
+- Provides AI-extractable content
+- Targets specific search queries
+
+### 3. Statistics Make Content Quotable
+
+"10+ Skills | 5 Platforms | One-Click Install | 100% Open Source"
+
+These specific numbers are:
+- Easy for AI to extract
+- Memorable for users
+- Differentiated from competitors
+
+### 4. Answer-First Structure
+
+Each FAQ answer starts with a direct answer:
+- "OPC Skills is a collection of..." (not "Well, it depends...")
+- This matches AI response patterns
+
+---
+
+## Next Steps
+
+### Short-term (1 month)
+
+- [ ] Submit sitemap to Google Search Console
+- [ ] Submit to Bing Webmaster Tools
+- [ ] Monitor indexing progress
+- [ ] Track FAQ rich results
+
+### Medium-term (3 months)
+
+- [ ] Monitor AI citation rate
+- [ ] A/B test different FAQ questions
+- [ ] Build backlinks from dev communities
+- [ ] Create content for Reddit/HN
+
+### Long-term (6 months)
+
+- [ ] Establish "OPC Skills = Solopreneur tools" brand
+- [ ] Rank for "Claude Code skills" in AI search
+- [ ] Get cited in AI responses about solopreneur tools
+
+---
+
+## Replication Guide
+
+To replicate this optimization for your own site:
+
+1. **Audit current state** using seo-geo skill checklist
+2. **Research keywords** - find long-tail opportunities
+3. **Write meta tags** - include primary keyword in title/description
+4. **Add Schema markup** - start with FAQPage and WebPage
+5. **Apply Princeton methods** - statistics, citations, structure
+6. **Configure AI bot access** - robots.txt
+7. **Validate schema** - Google Rich Results Test
+8. **Submit to search engines** - Search Console, Bing Webmaster
+9. **Monitor and iterate** - track visibility, adjust content
+
+---
+
+## Files Changed
+
+| File | Changes |
+|------|---------|
+| `website/worker.js` | Meta tags, Schema, Hero section, FAQ section, Stats bar |
+| `README.md` | Badges, navigation links, updated tagline |
+| `docs/MARKETING_SPEC.md` | Comprehensive marketing plan (new) |

--- a/.agents/skills/seo-geo/references/geo-research.md
+++ b/.agents/skills/seo-geo/references/geo-research.md
@@ -1,0 +1,319 @@
+# GEO Research: Princeton Study & Optimization Methods
+
+## Paper Overview
+
+**Title:** GEO: Generative Engine Optimization  
+**Authors:** Princeton University, IIT Delhi, Georgia Tech, Allen Institute for AI  
+**Published:** November 2023 (arXiv:2311.09735)  
+**Accepted:** KDD 2024 (30th ACM SIGKDD Conference)  
+**Link:** https://arxiv.org/abs/2311.09735
+
+---
+
+## Key Findings
+
+### What is GEO?
+
+**Generative Engine Optimization (GEO)** is a novel framework to help content creators improve their visibility in **generative engine responses** (AI search engines like ChatGPT, Perplexity, Google SGE).
+
+Unlike traditional SEO (ranking in search results), GEO focuses on **being cited** by AI systems.
+
+### Core Results
+
+| Metric | Result |
+|--------|--------|
+| **Maximum Visibility Boost** | Up to 40% |
+| **Low-ranking Sites Boost** | Up to 115% with citations |
+| **GEO-bench Dataset** | 10,000+ queries across domains |
+| **Tested on** | Perplexity.ai (commercial GE) |
+
+### Why GEO Matters
+
+1. **Traditional search engines are being replaced** by generative engines
+2. **Content creators have little control** over how their content appears in AI responses
+3. **GEO provides systematic methods** to improve visibility
+4. **Different domains need different strategies** - no one-size-fits-all
+
+---
+
+## The 9 Optimization Methods
+
+### Method 1: Cite Sources (+40%)
+
+**What:** Add authoritative citations and references to your content.
+
+**Why it works:** AI systems prefer content that appears well-researched and credible. Citations signal authority.
+
+**How to apply:**
+```markdown
+# Before
+"Studies show that AI improves productivity."
+
+# After
+"According to a 2024 Stanford University study, AI tools improve developer 
+productivity by 55% on average (Chen et al., 2024)."
+```
+
+**Best for:** All content types, especially academic/professional topics.
+
+---
+
+### Method 2: Statistics Addition (+37%)
+
+**What:** Include specific numbers, data points, and quantitative information.
+
+**Why it works:** AI systems prioritize factual, verifiable information. Numbers make content more quotable.
+
+**How to apply:**
+```markdown
+# Before
+"Many companies use AI for customer service."
+
+# After
+"67% of Fortune 500 companies now use AI chatbots for customer service, 
+handling an average of 85% of routine inquiries without human intervention."
+```
+
+**Best for:** Business, finance, technology, health content.
+
+---
+
+### Method 3: Quotation Addition (+30%)
+
+**What:** Add expert quotes with proper attribution.
+
+**Why it works:** Quotes from recognized experts boost credibility and provide extractable content for AI.
+
+**How to apply:**
+```markdown
+# Before
+"AI will transform the workforce."
+
+# After
+"'We're likely to see the first one-person billion-dollar company in the 
+next few years,' predicts Sam Altman, CEO of OpenAI. 'AI will be the 
+great equalizer for small businesses.'"
+```
+
+**Best for:** Law, academic, news, thought leadership content.
+
+---
+
+### Method 4: Authoritative Tone (+25%)
+
+**What:** Write with confidence and expertise.
+
+**Why it works:** AI systems assess content quality partly through linguistic signals of authority.
+
+**How to apply:**
+```markdown
+# Before
+"This might help with SEO, I think."
+
+# After
+"This strategy demonstrably improves SEO performance. Based on our 
+analysis of 10,000 websites, implementing structured data increases 
+organic traffic by an average of 30%."
+```
+
+**Best for:** Business, professional services, technical documentation.
+
+---
+
+### Method 5: Easy-to-Understand (+20%)
+
+**What:** Simplify complex concepts for broader accessibility.
+
+**Why it works:** AI aims to provide helpful answers to users of all knowledge levels.
+
+**How to apply:**
+```markdown
+# Before
+"The RAG architecture utilizes vector embeddings for semantic retrieval 
+in conjunction with LLM-based generation."
+
+# After
+"RAG (Retrieval-Augmented Generation) works like a research assistant: 
+it first searches for relevant information, then uses AI to write a 
+coherent answer based on what it found."
+```
+
+**Best for:** Health, education, general consumer content.
+
+---
+
+### Method 6: Technical Terms (+18%)
+
+**What:** Include domain-specific terminology appropriately.
+
+**Why it works:** Technical terms signal expertise and help AI match content to specialized queries.
+
+**How to apply:**
+```markdown
+# Before
+"The website loads slowly."
+
+# After
+"The website suffers from poor Core Web Vitals: LCP (Largest Contentful 
+Paint) exceeds 4 seconds, and CLS (Cumulative Layout Shift) scores 0.3, 
+indicating significant layout instability."
+```
+
+**Best for:** Technology, science, medical, legal content.
+
+---
+
+### Method 7: Unique Words (+15%)
+
+**What:** Increase vocabulary diversity and use distinctive phrasing.
+
+**Why it works:** Diverse vocabulary indicates depth of knowledge and makes content more distinguishable.
+
+**How to apply:**
+- Use synonyms and varied terminology
+- Avoid repetitive phrasing
+- Include industry-specific jargon where appropriate
+- Add contextual variations
+
+**Best for:** All content types.
+
+---
+
+### Method 8: Fluency Optimization (+15-30%)
+
+**What:** Improve readability, flow, and grammatical quality.
+
+**Why it works:** Well-written content is easier for AI to parse and more likely to be selected as authoritative.
+
+**How to apply:**
+- Use clear sentence structure
+- Maintain logical flow between paragraphs
+- Eliminate redundancy
+- Use transition words
+- Keep paragraphs focused (2-3 sentences)
+
+**Best for:** All content types.
+
+---
+
+### Method 9: Keyword Stuffing (-10%) ⚠️
+
+**What:** Overloading content with target keywords.
+
+**Why it HURTS:** Unlike traditional SEO, keyword stuffing actively decreases AI visibility.
+
+**Avoid:**
+```markdown
+# BAD - Keyword stuffing
+"SEO optimization for SEO is the best SEO strategy. Our SEO experts 
+provide SEO services for all your SEO needs. SEO is important for SEO."
+
+# GOOD - Natural writing
+"Search engine optimization is essential for online visibility. Our 
+experts help businesses improve their search rankings through strategic 
+content development and technical improvements."
+```
+
+---
+
+## Best Combinations
+
+The Princeton research found that combining methods yields better results:
+
+| Combination | Effectiveness |
+|-------------|--------------|
+| **Fluency + Statistics** | Highest overall boost |
+| **Citations + Authoritative Tone** | Best for professional content |
+| **Easy Language + Statistics** | Best for consumer content |
+| **Technical Terms + Citations** | Best for academic/scientific |
+
+---
+
+## Domain-Specific Recommendations
+
+| Domain | Best Methods | Avoid |
+|--------|-------------|-------|
+| **Technology** | Technical Terms, Citations, Statistics | Oversimplification |
+| **Business/Finance** | Statistics, Authoritative Tone, Citations | Vague claims |
+| **Healthcare** | Easy Language, Statistics, Citations | Jargon overload |
+| **Legal** | Citations, Quotations, Authoritative Tone | Informal language |
+| **Education** | Easy Language, Examples, Structure | Complexity |
+| **E-commerce** | Statistics, Social Proof, Clear Benefits | Feature dumps |
+
+---
+
+## GEO Metrics
+
+The paper introduces visibility metrics for evaluating GEO effectiveness:
+
+### Position-Adjusted Word Count
+
+Measures how much of your content appears in AI responses, weighted by position (earlier = better).
+
+### Subjective Impression Score
+
+Human evaluation of how prominently your content is featured in responses.
+
+### Word Count Share
+
+Percentage of AI response that comes from your content vs. competitors.
+
+---
+
+## Implementation Checklist
+
+### Content Optimization
+
+- [ ] Add 2-3 authoritative citations per major section
+- [ ] Include at least 5 relevant statistics with sources
+- [ ] Add 1-2 expert quotes with attribution
+- [ ] Use confident, authoritative language
+- [ ] Ensure content is accessible to general audience
+- [ ] Include appropriate technical terminology
+- [ ] Vary vocabulary throughout
+- [ ] Improve overall fluency and readability
+- [ ] Remove any keyword stuffing
+
+### Structure Optimization
+
+- [ ] Use "answer-first" format (direct answer at top)
+- [ ] Clear H1 > H2 > H3 hierarchy
+- [ ] Bullet points for lists
+- [ ] Tables for comparisons
+- [ ] Short paragraphs (2-3 sentences)
+- [ ] Logical flow between sections
+
+### Schema Optimization
+
+- [ ] Implement FAQPage schema (+40% AI visibility)
+- [ ] Add Article schema with author info
+- [ ] Include datePublished and dateModified
+- [ ] Add SpeakableSpecification for voice search
+
+---
+
+## Validation on Commercial Platforms
+
+The researchers validated GEO methods on **Perplexity.ai**, a commercial generative engine:
+
+| Method | Visibility Increase |
+|--------|-------------------|
+| Cite Sources | Up to 37% |
+| Statistics | Up to 35% |
+| Quotations | Up to 28% |
+| Combined methods | Up to 40% |
+
+These results confirm that GEO methods work on real-world AI search engines, not just research benchmarks.
+
+---
+
+## Future of GEO
+
+The paper concludes that GEO is essential for:
+
+1. **Content creators** - Maintain visibility in AI-dominated search
+2. **Businesses** - Ensure brand presence in AI responses
+3. **Publishers** - Adapt to the citation economy
+4. **SEO professionals** - Evolve practices for generative search
+
+As AI search engines become more prevalent, GEO will become as important as traditional SEO.

--- a/.agents/skills/seo-geo/references/google-docs-summary.md
+++ b/.agents/skills/seo-geo/references/google-docs-summary.md
@@ -1,0 +1,65 @@
+# Google Official SEO Documentation Summary
+
+Quick reference from Google Search Central.
+
+---
+
+## Search Three-Stage Process
+
+| Stage | Description | Focus |
+|-------|-------------|-------|
+| **Crawling** | Googlebot discovers pages | robots.txt, sitemap, links |
+| **Indexing** | Content analyzed and stored | Quality, canonical, noindex |
+| **Serving** | Results returned | Relevance, E-E-A-T, UX |
+
+---
+
+## Core Web Vitals
+
+| Metric | Good | Needs Work | Poor |
+|--------|------|------------|------|
+| **LCP** | < 2.5s | 2.5-4s | > 4s |
+| **FID** | < 100ms | 100-300ms | > 300ms |
+| **CLS** | < 0.1 | 0.1-0.25 | > 0.25 |
+
+---
+
+## Structured Data Types
+
+| Type | Use Case | Rich Result |
+|------|----------|-------------|
+| FAQPage | FAQ content | Expandable Q&A |
+| Article | Blog/news | Title + date |
+| Product | E-commerce | Price + rating |
+| HowTo | Tutorials | Steps |
+| VideoObject | Video | Thumbnail |
+| BreadcrumbList | Navigation | Breadcrumbs |
+
+---
+
+## Spam Policies (Avoid)
+
+- Keyword stuffing
+- Hidden text/links
+- Link schemes
+- Auto-generated content
+- Scraped content
+- Cloaking
+
+---
+
+## Official Tools
+
+| Tool | URL |
+|------|-----|
+| Search Console | search.google.com/search-console |
+| Rich Results Test | search.google.com/test/rich-results |
+| PageSpeed Insights | pagespeed.web.dev |
+| Mobile-Friendly Test | search.google.com/test/mobile-friendly |
+
+---
+
+## Reference
+
+- https://developers.google.com/search
+- https://developers.google.com/search/docs/fundamentals/seo-starter-guide

--- a/.agents/skills/seo-geo/references/platform-algorithms.md
+++ b/.agents/skills/seo-geo/references/platform-algorithms.md
@@ -1,0 +1,354 @@
+# Platform Ranking Algorithms
+
+Detailed ranking factors for AI search engines and traditional search engines (2025-2026).
+
+---
+
+## 1. ChatGPT Ranking Factors
+
+### Core Ranking System
+
+ChatGPT uses a **two-phase system**:
+1. **Pre-training Knowledge** - Built from diverse datasets (Wikipedia, books, web)
+2. **Real-time Retrieval** - Web browsing for current information
+
+### Ranking Factor Weights
+
+| Factor | Weight | Details |
+|--------|--------|---------|
+| **Authority & Credibility** | 40% | Branded domains preferred over third-party |
+| **Content Quality & Utility** | 35% | Clear structure, comprehensive answers |
+| **Platform Trust** | 25% | Wikipedia, Reddit, Forbes prioritized |
+
+### Key Findings (SE Ranking Study - 129K domains)
+
+| Metric | Impact |
+|--------|--------|
+| **Referring Domains** | Strongest predictor. >350K domains = 8.4 avg citations |
+| **Domain Trust Score** | 91-96 score = 6 citations; 97-100 = 8.4 citations |
+| **Content Recency** | 30-day old content gets 3.2x more citations |
+| **Branded vs Third-party** | Branded domains cited 11.1 points more than third-party |
+
+### ChatGPT Top Citation Sources
+
+| Rank | Source | % of Citations |
+|------|--------|---------------|
+| 1 | Wikipedia | 7.8% |
+| 2 | Reddit | 1.8% |
+| 3 | Forbes | 1.1% |
+| 4 | Brand Official Sites | Variable |
+| 5 | Academic Sources | Variable |
+
+### Content-Answer Fit Analysis (400K pages study)
+
+| Factor | Relevance |
+|--------|-----------|
+| **Content-Answer Fit** | 55% - Most important! Match ChatGPT's response style |
+| **On-Page Structure** | 14% - Clear headings, formatting |
+| **Domain Authority** | 12% - Helps retrieval, not citation |
+| **Query Relevance** | 12% - Match user intent |
+| **Content Consensus** | 7% - Agreement among sources |
+
+### Optimization Checklist
+
+- [ ] Build strong backlink profile (quality > quantity)
+- [ ] Update content within 30 days
+- [ ] Use clear H1/H2/H3 structure
+- [ ] Include verifiable statistics with citations
+- [ ] Write in ChatGPT's conversational style
+- [ ] Ensure domain has high trust score
+
+---
+
+## 2. Perplexity AI Ranking Factors
+
+### Architecture
+
+Perplexity uses **Retrieval-Augmented Generation (RAG)** with a **3-layer reranking system**:
+
+1. **Layer 1 (L1)**: Basic relevance retrieval
+2. **Layer 2 (L2)**: Traditional ranking factors scoring
+3. **Layer 3 (L3)**: ML models for quality evaluation (can discard entire result sets)
+
+### Core Ranking Factors
+
+| Factor | Details |
+|--------|---------|
+| **Authoritative Domain Lists** | Manual lists: Amazon, GitHub, academic sites get inherent boost |
+| **Freshness Signals** | Time decay algorithm; new content evaluated quickly |
+| **Semantic Relevance** | Content similarity to query (not keyword matching) |
+| **Topical Weighting** | Tech, AI, Science topics get visibility multipliers |
+| **User Engagement** | Click rates, weekly performance metrics |
+| **New Post Performance** | Early clicks significantly boost visibility |
+
+### Perplexity Sonar Model Insights
+
+| Signal | Impact |
+|--------|--------|
+| **FAQ Schema (JSON-LD)** | Pages with FAQ blocks cited more often |
+| **PDF Documents** | Publicly hosted PDFs prioritized |
+| **Content Velocity** | Speed of publishing matters more than keyword density |
+| **Semantic Payloads** | Clear, atomic paragraphs preferred |
+| **YouTube Sync** | YouTube titles matching trending queries get boost |
+
+### Technical Requirements
+
+```
+# robots.txt - Allow PerplexityBot
+User-agent: PerplexityBot
+Allow: /
+
+# Provide clean sitemap
+Sitemap: https://example.com/sitemap.xml
+```
+
+### Optimization Checklist
+
+- [ ] Allow PerplexityBot in robots.txt
+- [ ] Implement FAQ Schema markup
+- [ ] Create publicly accessible PDF resources
+- [ ] Use Article schema with timestamps
+- [ ] Focus on semantic relevance, not keywords
+- [ ] Build topical authority in your niche
+
+---
+
+## 3. Google AI Overview (SGE) Ranking Factors
+
+### Architecture
+
+Google AI Overviews use multiple AI models:
+- **PaLM2** - Language understanding
+- **MUM** - Multimodal understanding
+- **Gemini** - Advanced reasoning
+
+### 5-Stage Source Prioritization Pipeline
+
+1. **Retrieval** - Identify candidate sources
+2. **Semantic Ranking** - Evaluate topical relevance
+3. **LLM Re-ranking** - Assess contextual fit (using Gemini)
+4. **E-E-A-T Evaluation** - Filter for expertise/authority/trust
+5. **Data Fusion** - Synthesize from multiple sources with citations
+
+### Key Statistics
+
+| Metric | Value |
+|--------|-------|
+| AI Overviews in searches | 85%+ |
+| Overlap with traditional Top 10 | Only 15% |
+| Traditional factors weight | 62% |
+| Novel AI signals weight | 38% |
+| SGE-optimized visibility boost | 340% |
+
+### Ranking Factors
+
+| Factor | Details |
+|--------|---------|
+| **E-E-A-T** | Experience, Expertise, Authoritativeness, Trustworthiness |
+| **Structured Data** | Schema markup helps AI understand content |
+| **Knowledge Graph** | Being in Google's Knowledge Graph = boost |
+| **Topical Authority** | Content clusters + internal linking |
+| **Multimedia** | Images/videos in multi-modal responses |
+| **Authoritative Citations** | +132% visibility with trusted references |
+| **Authoritative Tone** | +89% visibility improvement |
+
+### Content Requirements
+
+```
+Traditional SEO still matters:
+- Quality backlinks
+- Original, helpful content
+- Fast page speed
+- Mobile-friendly design
+- Secure (HTTPS)
+```
+
+### Optimization Checklist
+
+- [ ] Implement comprehensive Schema markup
+- [ ] Build topical authority with content clusters
+- [ ] Include authoritative citations and references
+- [ ] Use E-E-A-T signals (author bios, credentials)
+- [ ] Optimize for Google Merchant Center (e-commerce)
+- [ ] Target informational "how-to" queries
+
+---
+
+## 4. Microsoft Copilot / Bing AI Ranking Factors
+
+### Architecture
+
+Copilot is integrated into:
+- Microsoft Edge browser
+- Windows 11
+- Microsoft 365 apps
+- Bing Search
+
+Uses **Bing Index** as primary data source.
+
+### Ranking Factors
+
+| Factor | Details |
+|--------|---------|
+| **Bing Index** | Must be indexed by Bing to be cited |
+| **Microsoft Ecosystem** | LinkedIn, GitHub mentions provide boost |
+| **Crawlability** | BingBot + PermaBot must have access |
+| **Page Speed** | < 2 seconds load time |
+| **Schema Markup** | Helps Copilot understand content |
+| **Entity Clarity** | Clear definitions of entities/concepts |
+
+### Technical Requirements
+
+```
+# robots.txt
+User-agent: Bingbot
+Allow: /
+
+User-agent: msnbot
+Allow: /
+
+# Submit to Bing Webmaster Tools
+# Use IndexNow for faster indexing
+```
+
+### Optimization Checklist
+
+- [ ] Submit site to Bing Webmaster Tools
+- [ ] Ensure Bingbot can crawl all pages
+- [ ] Use IndexNow for new content
+- [ ] Optimize page speed (< 2 seconds)
+- [ ] Clear entity definitions in content
+- [ ] Build presence on LinkedIn, GitHub
+
+---
+
+## 5. Claude AI Ranking Factors
+
+### Architecture
+
+**Important:** Claude uses **Brave Search**, NOT Google or Bing!
+
+Claude decides when to search based on:
+- Query freshness requirements
+- Specificity of question
+- User intent
+
+### Ranking Factors
+
+| Factor | Details |
+|--------|---------|
+| **Brave Index** | Must be indexed by Brave Search |
+| **Query Rewriting** | Claude reformulates queries for search |
+| **Factual Density** | Data-rich content preferred |
+| **Structural Clarity** | Easy to extract information |
+| **Source Authority** | Trustworthy, well-sourced content |
+
+### Key Statistic
+
+**Crawl-to-Refer Ratio: 38,065:1**
+- Claude consumes massive amounts of content
+- Very selective about what it cites
+- Quality and relevance are critical
+
+### Technical Requirements
+
+```
+# robots.txt
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+```
+
+### Optimization Checklist
+
+- [ ] Ensure Brave Search indexing
+- [ ] Allow ClaudeBot in robots.txt
+- [ ] Create high factual density content
+- [ ] Use clear, extractable structure
+- [ ] Include verifiable data points
+- [ ] Cite authoritative sources
+
+---
+
+## 6. Traditional Google SEO Ranking Factors (2026)
+
+### Core Ranking Systems
+
+| System | Purpose |
+|--------|---------|
+| **PageRank** | Link-based authority (still relevant) |
+| **BERT** | Natural language understanding |
+| **RankBrain** | Machine learning ranking |
+| **Helpful Content** | Rewards people-first content |
+| **Spam Detection** | Filters low-quality content |
+
+### Top 10 Ranking Factors
+
+| Rank | Factor | Details |
+|------|--------|---------|
+| 1 | **Backlinks** | Quality referring domains (core ranking system) |
+| 2 | **E-E-A-T** | Experience, Expertise, Authority, Trust |
+| 3 | **Content Quality** | Original, comprehensive, helpful |
+| 4 | **Page Experience** | Core Web Vitals (LCP, FID, CLS) |
+| 5 | **Mobile-First** | Non-mobile sites may not be indexed |
+| 6 | **Search Intent Match** | Content matches user query intent |
+| 7 | **Content Freshness** | Regular updates signal activity |
+| 8 | **Technical SEO** | Crawlable, indexable, HTTPS |
+| 9 | **User Signals** | Dwell time, bounce rate, CTR |
+| 10 | **Structured Data** | Schema markup for rich results |
+
+### Core Web Vitals
+
+| Metric | Good | Needs Improvement | Poor |
+|--------|------|-------------------|------|
+| **LCP** (Largest Contentful Paint) | < 2.5s | 2.5-4s | > 4s |
+| **FID** (First Input Delay) | < 100ms | 100-300ms | > 300ms |
+| **CLS** (Cumulative Layout Shift) | < 0.1 | 0.1-0.25 | > 0.25 |
+
+### E-E-A-T Guidelines
+
+| Signal | How to Demonstrate |
+|--------|-------------------|
+| **Experience** | First-hand experience, case studies |
+| **Expertise** | Author credentials, detailed knowledge |
+| **Authoritativeness** | Backlinks, mentions, citations |
+| **Trustworthiness** | Accurate info, transparent, secure site |
+
+### Optimization Checklist
+
+- [ ] Build quality backlinks (guest posts, PR, original research)
+- [ ] Create comprehensive, original content
+- [ ] Optimize Core Web Vitals
+- [ ] Ensure mobile-friendly design
+- [ ] Use HTTPS
+- [ ] Implement Schema markup
+- [ ] Match content to search intent
+- [ ] Update content regularly
+- [ ] Add author bios with credentials
+- [ ] Include E-E-A-T signals
+
+---
+
+## Cross-Platform Optimization Summary
+
+| Platform | Primary Index | Key Factor | Unique Requirement |
+|----------|--------------|------------|-------------------|
+| ChatGPT | Web (Bing-based) | Domain Authority | Content-Answer Fit |
+| Perplexity | Own + Google | Semantic Relevance | FAQ Schema |
+| Google SGE | Google | E-E-A-T | Knowledge Graph |
+| Copilot | Bing | Bing Index | MS Ecosystem |
+| Claude | Brave | Factual Density | Brave Indexing |
+| Google (traditional) | Google | Backlinks | Core Web Vitals |
+
+### Universal Best Practices
+
+1. **Allow all major bots** in robots.txt
+2. **Implement Schema markup** (FAQPage, Article, Organization)
+3. **Build authoritative backlinks**
+4. **Update content regularly** (within 30 days)
+5. **Use clear structure** (H1 > H2 > H3, lists, tables)
+6. **Include statistics and citations**
+7. **Optimize page speed** (< 2 seconds)
+8. **Ensure mobile-friendly design**

--- a/.agents/skills/seo-geo/references/schema-templates.md
+++ b/.agents/skills/seo-geo/references/schema-templates.md
@@ -1,0 +1,517 @@
+# JSON-LD Schema Templates
+
+Ready-to-use JSON-LD structured data templates for SEO and GEO optimization.
+
+---
+
+## 1. FAQPage Schema (+40% AI Visibility)
+
+**Best for:** FAQ sections, knowledge base pages, product pages with Q&A.
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What is [Your Product/Service]?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "[Comprehensive answer with statistics. According to X, 85% of users report Y benefit.]"
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How does [Product/Service] work?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "[Step-by-step explanation. First, you... Then... Finally...]"
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What are the benefits of [Product/Service]?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "[List key benefits with data. Users save an average of X hours per week.]"
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How much does [Product/Service] cost?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "[Pricing information. Plans start at $X/month with a free tier available.]"
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How do I get started with [Product/Service]?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "[Installation/signup instructions. Run: curl -fsSL example.com/install.sh | bash]"
+      }
+    }
+  ]
+}
+```
+
+---
+
+## 2. WebPage Schema
+
+**Best for:** Standard content pages, landing pages.
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  "name": "[Page Title]",
+  "description": "[Page description, 150-160 characters]",
+  "url": "https://example.com/page",
+  "datePublished": "2024-01-15",
+  "dateModified": "2024-12-20",
+  "inLanguage": "en-US",
+  "isPartOf": {
+    "@type": "WebSite",
+    "name": "[Site Name]",
+    "url": "https://example.com"
+  },
+  "author": {
+    "@type": "Person",
+    "name": "[Author Name]",
+    "url": "https://example.com/about"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "[Organization Name]",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://example.com/logo.png"
+    }
+  },
+  "speakable": {
+    "@type": "SpeakableSpecification",
+    "cssSelector": ["h1", ".summary", ".key-points"]
+  }
+}
+```
+
+---
+
+## 3. Article Schema
+
+**Best for:** Blog posts, news articles, tutorials.
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "[Article Title - Max 110 characters]",
+  "description": "[Article summary]",
+  "image": [
+    "https://example.com/image-1x1.jpg",
+    "https://example.com/image-4x3.jpg",
+    "https://example.com/image-16x9.jpg"
+  ],
+  "datePublished": "2024-01-15T08:00:00+00:00",
+  "dateModified": "2024-12-20T10:30:00+00:00",
+  "author": {
+    "@type": "Person",
+    "name": "[Author Name]",
+    "url": "https://example.com/author/name",
+    "jobTitle": "[Job Title]",
+    "worksFor": {
+      "@type": "Organization",
+      "name": "[Company]"
+    }
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "[Publisher Name]",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://example.com/logo.png",
+      "width": 600,
+      "height": 60
+    }
+  },
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "https://example.com/article-url"
+  },
+  "keywords": ["keyword1", "keyword2", "keyword3"],
+  "articleSection": "[Category]",
+  "wordCount": 2500
+}
+```
+
+---
+
+## 4. SoftwareApplication Schema
+
+**Best for:** Tools, apps, software products.
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  "name": "[App Name]",
+  "description": "[App description]",
+  "applicationCategory": "DeveloperApplication",
+  "operatingSystem": "Cross-platform",
+  "url": "https://example.com",
+  "downloadUrl": "https://example.com/download",
+  "softwareVersion": "1.0.0",
+  "releaseNotes": "https://example.com/changelog",
+  "screenshot": "https://example.com/screenshot.png",
+  "featureList": [
+    "Feature 1 description",
+    "Feature 2 description",
+    "Feature 3 description"
+  ],
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD",
+    "availability": "https://schema.org/InStock"
+  },
+  "aggregateRating": {
+    "@type": "AggregateRating",
+    "ratingValue": "4.8",
+    "ratingCount": "150",
+    "bestRating": "5",
+    "worstRating": "1"
+  },
+  "author": {
+    "@type": "Organization",
+    "name": "[Company Name]",
+    "url": "https://example.com"
+  }
+}
+```
+
+---
+
+## 5. Organization Schema
+
+**Best for:** About pages, company pages.
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  "name": "[Organization Name]",
+  "alternateName": "[Alternate Name]",
+  "url": "https://example.com",
+  "logo": "https://example.com/logo.png",
+  "description": "[Organization description]",
+  "foundingDate": "2024",
+  "founders": [
+    {
+      "@type": "Person",
+      "name": "[Founder Name]"
+    }
+  ],
+  "address": {
+    "@type": "PostalAddress",
+    "addressLocality": "[City]",
+    "addressRegion": "[State]",
+    "addressCountry": "[Country]"
+  },
+  "contactPoint": {
+    "@type": "ContactPoint",
+    "contactType": "customer service",
+    "email": "support@example.com"
+  },
+  "sameAs": [
+    "https://twitter.com/example",
+    "https://github.com/example",
+    "https://linkedin.com/company/example"
+  ]
+}
+```
+
+---
+
+## 6. Product Schema
+
+**Best for:** E-commerce product pages.
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "Product",
+  "name": "[Product Name]",
+  "description": "[Product description]",
+  "image": [
+    "https://example.com/product-image-1.jpg",
+    "https://example.com/product-image-2.jpg"
+  ],
+  "sku": "[SKU]",
+  "brand": {
+    "@type": "Brand",
+    "name": "[Brand Name]"
+  },
+  "offers": {
+    "@type": "Offer",
+    "url": "https://example.com/product",
+    "priceCurrency": "USD",
+    "price": "99.99",
+    "priceValidUntil": "2025-12-31",
+    "availability": "https://schema.org/InStock",
+    "seller": {
+      "@type": "Organization",
+      "name": "[Seller Name]"
+    }
+  },
+  "aggregateRating": {
+    "@type": "AggregateRating",
+    "ratingValue": "4.5",
+    "reviewCount": "89"
+  },
+  "review": [
+    {
+      "@type": "Review",
+      "reviewRating": {
+        "@type": "Rating",
+        "ratingValue": "5",
+        "bestRating": "5"
+      },
+      "author": {
+        "@type": "Person",
+        "name": "[Reviewer Name]"
+      },
+      "reviewBody": "[Review text]"
+    }
+  ]
+}
+```
+
+---
+
+## 7. HowTo Schema
+
+**Best for:** Tutorials, guides, how-to articles.
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "How to [Do Something]",
+  "description": "[Brief description of what this guide covers]",
+  "image": "https://example.com/how-to-image.jpg",
+  "totalTime": "PT15M",
+  "estimatedCost": {
+    "@type": "MonetaryAmount",
+    "currency": "USD",
+    "value": "0"
+  },
+  "supply": [
+    {
+      "@type": "HowToSupply",
+      "name": "[Required item 1]"
+    }
+  ],
+  "tool": [
+    {
+      "@type": "HowToTool",
+      "name": "[Required tool 1]"
+    }
+  ],
+  "step": [
+    {
+      "@type": "HowToStep",
+      "name": "Step 1: [Step Name]",
+      "text": "[Detailed step instructions]",
+      "image": "https://example.com/step-1.jpg",
+      "url": "https://example.com/guide#step1"
+    },
+    {
+      "@type": "HowToStep",
+      "name": "Step 2: [Step Name]",
+      "text": "[Detailed step instructions]",
+      "image": "https://example.com/step-2.jpg",
+      "url": "https://example.com/guide#step2"
+    },
+    {
+      "@type": "HowToStep",
+      "name": "Step 3: [Step Name]",
+      "text": "[Detailed step instructions]",
+      "image": "https://example.com/step-3.jpg",
+      "url": "https://example.com/guide#step3"
+    }
+  ]
+}
+```
+
+---
+
+## 8. BreadcrumbList Schema
+
+**Best for:** All pages with navigation hierarchy.
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://example.com"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "[Category]",
+      "item": "https://example.com/category"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "[Current Page]",
+      "item": "https://example.com/category/page"
+    }
+  ]
+}
+```
+
+---
+
+## 9. LocalBusiness Schema
+
+**Best for:** Local business pages.
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "LocalBusiness",
+  "name": "[Business Name]",
+  "description": "[Business description]",
+  "image": "https://example.com/business-image.jpg",
+  "url": "https://example.com",
+  "telephone": "+1-555-555-5555",
+  "email": "contact@example.com",
+  "address": {
+    "@type": "PostalAddress",
+    "streetAddress": "[Street Address]",
+    "addressLocality": "[City]",
+    "addressRegion": "[State]",
+    "postalCode": "[ZIP]",
+    "addressCountry": "US"
+  },
+  "geo": {
+    "@type": "GeoCoordinates",
+    "latitude": 37.7749,
+    "longitude": -122.4194
+  },
+  "openingHoursSpecification": [
+    {
+      "@type": "OpeningHoursSpecification",
+      "dayOfWeek": ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"],
+      "opens": "09:00",
+      "closes": "17:00"
+    }
+  ],
+  "priceRange": "$$"
+}
+```
+
+---
+
+## 10. SpeakableSpecification (GEO Enhancement)
+
+**Best for:** Voice search optimization, AI extraction.
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  "name": "[Page Title]",
+  "speakable": {
+    "@type": "SpeakableSpecification",
+    "cssSelector": [
+      "h1",
+      ".summary",
+      ".key-takeaways",
+      ".faq-answer"
+    ]
+  }
+}
+```
+
+---
+
+## Combined Schema Example
+
+For a software product page with FAQ:
+
+```json
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "WebPage",
+      "name": "OPC Skills - AI Agent Skills for Solopreneurs",
+      "description": "10+ agent skills for Claude Code, Cursor, Codex. Domain hunting, social media research, logo creation.",
+      "url": "https://opc.dev",
+      "dateModified": "2024-12-20",
+      "speakable": {
+        "@type": "SpeakableSpecification",
+        "cssSelector": ["h1", ".hero-description", ".faq-answer"]
+      }
+    },
+    {
+      "@type": "SoftwareApplication",
+      "name": "OPC Skills",
+      "applicationCategory": "DeveloperApplication",
+      "operatingSystem": "Cross-platform",
+      "offers": {
+        "@type": "Offer",
+        "price": "0",
+        "priceCurrency": "USD"
+      }
+    },
+    {
+      "@type": "FAQPage",
+      "mainEntity": [
+        {
+          "@type": "Question",
+          "name": "What is OPC Skills?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "OPC Skills is a collection of 10+ AI agent skills for solopreneurs, supporting Claude Code, Cursor, and Codex."
+          }
+        }
+      ]
+    },
+    {
+      "@type": "Organization",
+      "name": "OPC Skills",
+      "url": "https://opc.dev",
+      "sameAs": ["https://github.com/ReScienceLab/opc-skills"]
+    }
+  ]
+}
+```
+
+---
+
+## Validation Tools
+
+1. **Google Rich Results Test**
+   ```
+   https://search.google.com/test/rich-results?url={your-url}
+   ```
+
+2. **Schema.org Validator**
+   ```
+   https://validator.schema.org/?url={your-url}
+   ```
+
+3. **Google Search Console**
+   - Check "Enhancements" for schema issues
+   - Monitor rich result performance

--- a/.agents/skills/seo-geo/references/seo-checklist.md
+++ b/.agents/skills/seo-geo/references/seo-checklist.md
@@ -1,0 +1,249 @@
+# SEO/GEO Audit Checklist
+
+Complete checklist for auditing and optimizing websites for both traditional SEO and GEO (AI search visibility).
+
+## Priority Levels
+
+| Level | Meaning | Action |
+|-------|---------|--------|
+| **P0** | Critical | Must fix immediately - blocks indexing or causes major issues |
+| **P1** | Important | Should fix soon - significant impact on rankings |
+| **P2** | Recommended | Nice to have - improves visibility and user experience |
+
+---
+
+## Technical SEO
+
+### P0 - Critical
+
+- [ ] **P0** `robots.txt` allows important pages
+- [ ] **P0** Site is accessible (no 5xx errors)
+- [ ] **P0** HTTPS enabled (valid SSL certificate)
+- [ ] **P0** Mobile-responsive design
+- [ ] **P0** No critical pages blocked by `noindex`
+- [ ] **P0** Site is indexed in Google (check: `site:domain.com`)
+
+### P1 - Important
+
+- [ ] **P1** `robots.txt` allows AI bots (GPTBot, PerplexityBot, ClaudeBot)
+- [ ] **P1** XML sitemap exists and is submitted
+- [ ] **P1** Site is indexed in Bing (for Copilot visibility)
+- [ ] **P1** Canonical tags properly implemented
+- [ ] **P1** No duplicate content issues
+- [ ] **P1** Page load time < 3 seconds
+- [ ] **P1** LCP (Largest Contentful Paint) < 2.5s
+
+### P2 - Recommended
+
+- [ ] **P2** FID (First Input Delay) < 100ms
+- [ ] **P2** CLS (Cumulative Layout Shift) < 0.1
+- [ ] **P2** Images optimized (WebP format, lazy loading)
+- [ ] **P2** CSS/JS minified
+- [ ] **P2** GZIP/Brotli compression enabled
+- [ ] **P2** CDN configured
+- [ ] **P2** Mobile-friendly test passed
+- [ ] **P2** No mixed content warnings
+- [ ] **P2** Secure headers configured
+
+---
+
+## On-Page SEO
+
+### P0 - Critical
+
+- [ ] **P0** Unique `<title>` tag exists (50-60 characters)
+- [ ] **P0** Title contains primary keyword
+- [ ] **P0** Unique `<meta description>` exists (150-160 characters)
+- [ ] **P0** Single H1 tag per page
+- [ ] **P0** H1 contains primary keyword
+
+### P1 - Important
+
+- [ ] **P1** Description is compelling and includes keyword
+- [ ] **P1** `<meta name="robots">` correctly set
+- [ ] **P1** Logical heading hierarchy (H1 > H2 > H3)
+- [ ] **P1** All images have `alt` attributes
+- [ ] **P1** Internal links to related content
+- [ ] **P1** No broken links (404s)
+- [ ] **P1** Anchor text is descriptive
+
+### P2 - Recommended
+
+- [ ] **P2** `og:title` set
+- [ ] **P2** `og:description` set
+- [ ] **P2** `og:image` set (1200x630px recommended)
+- [ ] **P2** `og:url` set (canonical URL)
+- [ ] **P2** `og:type` set (website/article)
+- [ ] **P2** `twitter:card` set (summary_large_image)
+- [ ] **P2** `twitter:title` set
+- [ ] **P2** `twitter:description` set
+- [ ] **P2** `twitter:image` set
+- [ ] **P2** Paragraphs are short (2-3 sentences)
+- [ ] **P2** Bullet points used for lists
+- [ ] **P2** Tables used for comparisons
+- [ ] **P2** Alt text includes keywords where natural
+- [ ] **P2** Image file names are descriptive
+- [ ] **P2** External links have `rel="noopener noreferrer"`
+
+---
+
+## Schema Markup (Structured Data)
+
+### P1 - Important
+
+- [ ] **P1** Organization schema on homepage
+- [ ] **P1** WebPage schema on all pages
+- [ ] **P1** Article schema on blog posts
+- [ ] **P1** Schema passes Google Rich Results Test
+- [ ] **P1** No errors in Search Console "Enhancements"
+
+### P2 - Recommended - GEO Enhanced
+
+- [ ] **P2** FAQPage schema on FAQ sections (+40% AI visibility)
+- [ ] **P2** BreadcrumbList schema for navigation
+- [ ] **P2** SpeakableSpecification for voice search
+- [ ] **P2** datePublished and dateModified included
+- [ ] **P2** Author information with credentials
+- [ ] **P2** Publisher information with logo
+- [ ] **P2** Schema passes Schema.org Validator
+
+---
+
+## GEO Optimization (AI Search)
+
+### P1 - Important - Princeton GEO Methods
+
+- [ ] **P1** Content includes authoritative citations (+40%)
+- [ ] **P1** Statistics and data points included (+37%)
+- [ ] **P1** Expert quotes with attribution (+30%)
+- [ ] **P1** NO keyword stuffing (causes -10%)
+
+### P2 - Recommended - GEO Enhancement
+
+- [ ] **P2** Authoritative, confident tone (+25%)
+- [ ] **P2** Content is accessible/easy to understand (+20%)
+- [ ] **P2** Appropriate technical terminology (+18%)
+- [ ] **P2** Diverse vocabulary throughout (+15%)
+- [ ] **P2** High fluency and readability (+15-30%)
+
+### Content Structure for AI
+
+- [ ] "Answer-first" format (direct answer at top)
+- [ ] Clear, extractable paragraphs
+- [ ] FAQ format for common questions
+- [ ] Tables for comparison data
+- [ ] Lists for step-by-step processes
+
+### AI Bot Access
+
+- [ ] GPTBot allowed in robots.txt
+- [ ] PerplexityBot allowed in robots.txt
+- [ ] ClaudeBot allowed in robots.txt
+- [ ] Anthropic-ai allowed in robots.txt
+- [ ] Bingbot allowed in robots.txt
+
+---
+
+## Off-Page SEO
+
+### Backlinks
+
+- [ ] Quality backlinks from relevant sites
+- [ ] Diverse referring domains
+- [ ] No toxic/spammy backlinks
+- [ ] Brand mentions (even without links)
+
+### E-E-A-T Signals
+
+- [ ] Author bios with credentials
+- [ ] About page with company info
+- [ ] Contact information visible
+- [ ] Privacy policy and terms
+- [ ] Trust badges/certifications if applicable
+- [ ] Customer reviews/testimonials
+
+### Social Presence
+
+- [ ] Active social media profiles
+- [ ] Links to social profiles on website
+- [ ] Social sharing buttons on content
+- [ ] Consistent branding across platforms
+
+---
+
+## Content Strategy
+
+### Content Audit
+
+- [ ] All pages have unique, valuable content
+- [ ] No thin content (< 300 words for main pages)
+- [ ] Content matches search intent
+- [ ] Content is up-to-date (within 30 days for news/tech)
+- [ ] Content provides unique value vs competitors
+
+### Keyword Strategy
+
+- [ ] Primary keyword identified for each page
+- [ ] Secondary keywords mapped
+- [ ] Long-tail keywords targeted
+- [ ] No keyword cannibalization
+- [ ] Keywords match user intent
+
+---
+
+## Monitoring & Analytics
+
+### Setup
+
+- [ ] Google Analytics installed
+- [ ] Google Search Console connected
+- [ ] Bing Webmaster Tools connected
+- [ ] Sitemap submitted to both
+
+### Regular Checks
+
+- [ ] Weekly: Check Search Console for errors
+- [ ] Weekly: Review Core Web Vitals
+- [ ] Monthly: Analyze organic traffic trends
+- [ ] Monthly: Review top performing pages
+- [ ] Quarterly: Full SEO audit
+
+---
+
+## Quick Audit Commands
+
+```bash
+# Check meta tags
+curl -sL "https://example.com" | grep -E "<title>|<meta"
+
+# Check robots.txt
+curl -s "https://example.com/robots.txt"
+
+# Check sitemap
+curl -s "https://example.com/sitemap.xml" | head -30
+
+# Check page speed (using PageSpeed Insights API)
+# Requires API key
+curl "https://www.googleapis.com/pagespeedonline/v5/runPagespeed?url=https://example.com&strategy=mobile"
+
+# Check if indexed in Google
+# Manual check: https://www.google.com/search?q=site:example.com
+
+# Validate schema
+# Open: https://search.google.com/test/rich-results?url=https://example.com
+```
+
+---
+
+## Priority Matrix
+
+| Priority | Task | Impact |
+|----------|------|--------|
+| **Critical** | Fix crawl errors | Blocks indexing |
+| **Critical** | HTTPS enabled | Trust + ranking |
+| **High** | Core Web Vitals | UX + ranking |
+| **High** | Mobile-friendly | 60%+ traffic |
+| **High** | FAQPage schema | +40% AI visibility |
+| **Medium** | Meta descriptions | CTR improvement |
+| **Medium** | Internal linking | Authority distribution |
+| **Low** | Social meta tags | Share appearance |

--- a/.agents/skills/seo-geo/references/tools-and-apis.md
+++ b/.agents/skills/seo-geo/references/tools-and-apis.md
@@ -1,0 +1,313 @@
+# SEO/GEO Tools and API Reference
+
+Curated list of tools and APIs for SEO and GEO optimization.
+
+---
+
+## Free Tools
+
+### Schema Markup Generators
+
+| Tool | URL | Features |
+|------|-----|----------|
+| **TechnicalSEO.com** | technicalseo.com/tools/schema-markup-generator | Multiple schema types, validation |
+| **Rank Ranger** | rankranger.com/schema-markup-generator | FAQ, Article, Product schemas |
+| **Merkle** | technicalseo.com/tools/schema-markup-generator | Comprehensive schema generator |
+| **JSON-LD Generator** | jsonld.com | Simple schema builder |
+
+### Validation Tools
+
+| Tool | URL | Purpose |
+|------|-----|---------|
+| **Google Rich Results Test** | search.google.com/test/rich-results | Test schema markup |
+| **Schema.org Validator** | validator.schema.org | Validate any schema |
+| **Google Mobile-Friendly Test** | search.google.com/test/mobile-friendly | Mobile usability |
+| **PageSpeed Insights** | pagespeed.web.dev | Core Web Vitals |
+
+### SEO Audit Tools
+
+| Tool | URL | Features |
+|------|-----|----------|
+| **SEOmator** | seomator.com/free-seo-audit-tool | Comprehensive free audit |
+| **Screaming Frog (Free)** | screamingfrog.co.uk | Crawl up to 500 URLs |
+| **Google Search Console** | search.google.com/search-console | Official Google data |
+| **Bing Webmaster Tools** | bing.com/webmasters | Bing indexing data |
+
+---
+
+## Paid SEO Tools
+
+### Comprehensive Platforms
+
+| Tool | Price | Best For |
+|------|-------|----------|
+| **Ahrefs** | $99/mo+ | Backlink analysis, keyword research |
+| **Semrush** | $139/mo+ | All-in-one SEO + GEO toolkit |
+| **Moz Pro** | $99/mo+ | Domain authority, link building |
+| **SE Ranking** | $65/mo+ | Affordable all-in-one |
+
+### Content Optimization
+
+| Tool | Price | Best For |
+|------|-------|----------|
+| **Surfer SEO** | $89/mo+ | Content optimization for AI |
+| **Clearscope** | $170/mo+ | Enterprise content optimization |
+| **Frase** | $15/mo+ | AI content briefs |
+| **MarketMuse** | $149/mo+ | Content strategy |
+
+---
+
+## GEO / AI Visibility Tools
+
+### AI Search Monitoring
+
+| Tool | Price | Platforms |
+|------|-------|-----------|
+| **Profound** | $499/mo+ | ChatGPT, Perplexity, Claude, Gemini |
+| **Otterly.ai** | Free trial | ChatGPT, Perplexity, Google AIO |
+| **SE Ranking AI Toolkit** | Included | AI Overviews, ChatGPT |
+| **Semrush AI Visibility** | Included | Google AIO, ChatGPT |
+| **Peec AI** | Mid-tier | Sentiment + visibility |
+| **Scrunch AI** | Varies | Brand tracking, citations |
+
+### AI Visibility Features to Look For
+
+- Citation tracking across AI platforms
+- Prompt-level insights
+- Source attribution
+- Sentiment analysis
+- Competitive benchmarking
+- Actionable recommendations
+
+---
+
+## APIs for Automation
+
+### Google APIs
+
+| API | Purpose | Docs |
+|-----|---------|------|
+| **Search Console API** | Indexing status, search data | developers.google.com/webmaster-tools |
+| **PageSpeed API** | Core Web Vitals data | developers.google.com/speed/docs/insights/v5/get-started |
+| **Indexing API** | Request indexing | developers.google.com/search/apis/indexing-api |
+| **Custom Search API** | Programmatic search | developers.google.com/custom-search |
+
+### SEO Data APIs
+
+| API | Purpose | Pricing |
+|-----|---------|---------|
+| **DataForSEO** | Comprehensive SEO data | Pay-per-use |
+| **Moz API** | DA, PA, link data | Included with Moz |
+| **Ahrefs API** | Backlinks, keywords | Included with Ahrefs |
+| **SE Ranking API** | Rankings, audits | Included with SE Ranking |
+| **SEO Review Tools API** | Various SEO checks | Free tier available |
+
+### Schema/Metadata APIs
+
+| API | Purpose | Pricing |
+|-----|---------|---------|
+| **Apify Metadata Extractor** | Extract meta, sitemap, robots | $12/mo+ |
+| **Firecrawl** | Website crawling for SEO | Pay-per-use |
+
+---
+
+## Browser Extensions
+
+### SEO Analysis
+
+| Extension | Browser | Features |
+|-----------|---------|----------|
+| **SEOquake** | Chrome/Firefox | Quick SEO metrics |
+| **MozBar** | Chrome | DA, PA, link data |
+| **Ahrefs SEO Toolbar** | Chrome | Backlinks, keywords |
+| **Detailed SEO Extension** | Chrome | Technical SEO checks |
+
+### Schema Testing
+
+| Extension | Browser | Features |
+|-----------|---------|----------|
+| **Structured Data Testing Tool** | Chrome | View page schema |
+| **Schema Builder** | Chrome | Generate schema |
+
+---
+
+## Command Line Tools
+
+### curl Commands for SEO Checks
+
+```bash
+# Check meta tags
+curl -sL "https://example.com" | grep -E "<title>|<meta"
+
+# Check robots.txt
+curl -s "https://example.com/robots.txt"
+
+# Check sitemap
+curl -s "https://example.com/sitemap.xml"
+
+# Check HTTP headers
+curl -I "https://example.com"
+
+# Check redirect chain
+curl -sIL "https://example.com" | grep -E "HTTP|Location"
+
+# Check page size
+curl -sL "https://example.com" | wc -c
+
+# Check load time
+curl -o /dev/null -s -w "Total: %{time_total}s\n" "https://example.com"
+```
+
+### Using Google APIs via curl
+
+```bash
+# PageSpeed Insights (no API key needed for basic)
+curl "https://www.googleapis.com/pagespeedonline/v5/runPagespeed?url=https://example.com"
+
+# With API key (more requests allowed)
+curl "https://www.googleapis.com/pagespeedonline/v5/runPagespeed?url=https://example.com&key=YOUR_API_KEY"
+```
+
+---
+
+## Robots.txt Template for AI Bots
+
+```
+# Search Engines
+User-agent: Googlebot
+Allow: /
+
+User-agent: Bingbot
+Allow: /
+
+# AI Bots
+User-agent: GPTBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: Applebot-Extended
+Allow: /
+
+# Sitemap
+Sitemap: https://example.com/sitemap.xml
+```
+
+---
+
+## Scripts
+
+Ready-to-use Python scripts in `scripts/` folder.
+
+### Setup (DataForSEO scripts)
+
+```bash
+export DATAFORSEO_LOGIN=your_login
+export DATAFORSEO_PASSWORD=your_password
+```
+
+### seo_audit.py
+
+Full SEO audit - meta tags, robots.txt, sitemap, load time, schema, AI bot access. No API required.
+
+```bash
+python3 scripts/seo_audit.py "https://example.com"
+```
+
+### keyword_research.py
+
+Get keyword ideas, search volume, difficulty.
+
+```bash
+python3 scripts/keyword_research.py "seo tools" --limit 20
+python3 scripts/keyword_research.py "seo tools" --location 2826  # UK
+```
+
+### serp_analysis.py
+
+Analyze top 20 Google results for a keyword.
+
+```bash
+python3 scripts/serp_analysis.py "best seo tools" --depth 20
+```
+
+### backlinks.py
+
+Get backlink profile for a domain.
+
+```bash
+python3 scripts/backlinks.py "example.com" --limit 20
+```
+
+### domain_overview.py
+
+Get domain metrics - traffic, keywords, rankings.
+
+```bash
+python3 scripts/domain_overview.py "example.com"
+```
+
+---
+
+## Workflow Integration
+
+### Using with OPC Skills
+
+```bash
+# Use twitter skill to find SEO tips
+python3 scripts/search_tweets.py "SEO tips 2026" --limit 20
+
+# Use reddit skill to find discussions
+python3 scripts/search_posts.py "GEO optimization" --subreddit SEO --limit 10
+
+# Use WebSearch for keyword research
+# (Built into agent)
+```
+
+### Automation Ideas
+
+1. **Weekly SEO audit** - Crawl site with curl, check for errors
+2. **Schema monitoring** - Validate schema after deploys with Rich Results Test API
+3. **Ranking tracking** - Monitor AI visibility with Otterly.ai or Profound
+4. **Content freshness** - Flag outdated content based on dateModified
+5. **Competitor monitoring** - Track competitor changes with DataForSEO API
+
+---
+
+## Resources
+
+### Learning
+
+| Resource | URL | Type |
+|----------|-----|------|
+| **Google SEO Guide** | developers.google.com/search/docs | Official |
+| **Moz Beginner's Guide** | moz.com/beginners-guide-to-seo | Tutorial |
+| **Backlinko** | backlinko.com/hub/seo | Advanced |
+| **Search Engine Journal** | searchenginejournal.com | News |
+
+### GEO Research
+
+| Resource | URL | Type |
+|----------|-----|------|
+| **Princeton GEO Paper** | arxiv.org/abs/2311.09735 | Research |
+| **GEO Guide (SingleGrain)** | singlegrain.com/geo | Guide |
+| **AI Search Optimization (Semrush)** | semrush.com/blog/ai-search-optimization | Tutorial |
+
+### Communities
+
+| Community | Platform | Focus |
+|-----------|----------|-------|
+| **r/SEO** | Reddit | General SEO |
+| **r/bigseo** | Reddit | Advanced SEO |
+| **r/TechSEO** | Reddit | Technical SEO |
+| **SEO Twitter** | Twitter | News, tips |

--- a/.agents/skills/seo-geo/scripts/autocomplete_ideas.py
+++ b/.agents/skills/seo-geo/scripts/autocomplete_ideas.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""
+Google Autocomplete keyword suggestions using DataForSEO API
+Get real-time search suggestions from Google Autocomplete
+
+Usage: python3 scripts/autocomplete_ideas.py "Claude Code"
+"""
+import argparse
+from dataforseo_api import api_post, get_result
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Google Autocomplete keyword suggestions")
+    parser.add_argument("keyword", help="Seed keyword for autocomplete")
+    parser.add_argument("--location", "-loc", type=int, default=2840,
+                        help="Location code (default: 2840 = US)")
+    args = parser.parse_args()
+
+    data = [{
+        "keyword": args.keyword,
+        "location_code": args.location,
+        "language_code": "en"
+    }]
+    
+    response = api_post("serp/google/autocomplete/live/advanced", data)
+    results = get_result(response)
+    
+    print(f"keyword: {args.keyword}")
+    print(f"location: {args.location}")
+    print()
+    
+    if results:
+        suggestions = []
+        for result in results:
+            items = result.get("items", [])
+            
+            # Try different possible field names if items is empty
+            if not items:
+                items = result.get("autocomplete", [])
+                if not items:
+                    items = result.get("suggestions", [])
+            
+            for item in items:
+                # Handle different response formats
+                suggestion = None
+                if isinstance(item, dict):
+                    if item.get("type") == "autocomplete_item":
+                        suggestion = item.get("title", "").strip()
+                    elif "value" in item:
+                        suggestion = item.get("value", "").strip()
+                elif isinstance(item, str):
+                    suggestion = item.strip()
+                
+                if suggestion:
+                    suggestions.append(suggestion)
+        
+        if suggestions:
+            print(f"autocomplete_suggestions[{len(suggestions)}]:")
+            for i, suggestion in enumerate(suggestions, 1):
+                print(f"  {i}. {suggestion}")
+        else:
+            print("No suggestions found")
+    else:
+        print("No results found")
+    
+    print()
+    print("Tip: These are real user searches. Use them to:")
+    print("  - Create content matching user intent")
+    print("  - Optimize page titles and meta descriptions")
+    print("  - Discover long-tail keyword opportunities")
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/seo-geo/scripts/backlinks.py
+++ b/.agents/skills/seo-geo/scripts/backlinks.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""
+Backlinks analysis using DataForSEO API
+Usage: python3 scripts/backlinks.py "example.com" --limit 20
+"""
+import argparse
+from dataforseo_api import api_post, get_result, print_backlinks_list, format_count
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Backlinks analysis")
+    parser.add_argument("target", help="Target domain")
+    parser.add_argument("--limit", "-l", type=int, default=20, help="Max results")
+    args = parser.parse_args()
+
+    data = [{
+        "target": args.target,
+        "limit": args.limit,
+        "order_by": ["rank,desc"]
+    }]
+    
+    response = api_post("backlinks/backlinks/live", data)
+    results = get_result(response)
+    
+    print(f"target: {args.target}")
+    
+    if results:
+        result = results[0]
+        print(f"total_backlinks: {format_count(result.get('total_count'))}")
+        items = result.get("items", [])
+        print_backlinks_list(items[:args.limit])
+    else:
+        print("No results found")
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/seo-geo/scripts/competitor_gap.py
+++ b/.agents/skills/seo-geo/scripts/competitor_gap.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""
+Competitor keyword gap analysis using DataForSEO API
+Finds keywords where competitor ranks but you don't
+
+Usage: python3 scripts/competitor_gap.py "opc.dev" "claudemarketplaces.com" --limit 50
+"""
+import argparse
+from dataforseo_api import api_post, get_result, format_count
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Competitor keyword gap analysis")
+    parser.add_argument("my_domain", help="Your domain (without https://)")
+    parser.add_argument("competitor_domain", help="Competitor domain (without https://)")
+    parser.add_argument("--location", "-loc", type=int, default=2840,
+                        help="Location code (default: 2840 = US)")
+    parser.add_argument("--limit", "-l", type=int, default=50, 
+                        help="Max results (default: 50)")
+    args = parser.parse_args()
+
+    data = [{
+        "target1": args.my_domain,
+        "target2": args.competitor_domain,
+        "location_code": args.location,
+        "language_code": "en",
+        "intersections": False,  # Only show keywords where target2 ranks but target1 doesn't
+        "limit": args.limit
+    }]
+    
+    response = api_post("dataforseo_labs/google/domain_intersection/live", data)
+    results = get_result(response)
+    
+    print(f"my_domain: {args.my_domain}")
+    print(f"competitor_domain: {args.competitor_domain}")
+    print(f"location: {args.location}")
+    print()
+    
+    if results:
+        all_items = []
+        for result in results:
+            items = result.get("items", [])
+            if items:
+                all_items.extend(items)
+        
+        if not all_items:
+            print("No keyword gaps found")
+            return
+        
+        # Results show keywords where competitor ranks but you don't
+        print(f"keyword_gaps[{len(all_items)}]{{keyword,volume,difficulty,comp_position}}:")
+        for item in all_items:
+            kw_data = item.get("keyword_data", {})
+            keyword = kw_data.get("keyword", "N/A")
+            
+            # Get search volume from keyword_info
+            kw_info = kw_data.get("keyword_info", {})
+            volume = format_count(kw_info.get("search_volume", 0))
+            
+            # Get keyword difficulty
+            difficulty = kw_info.get("competition_level", "N/A")
+            
+            # Get competitor's ranking position
+            # When intersections=false, we get keywords where only second_domain (competitor) ranks
+            comp_element = item.get("second_domain_serp_element")
+            if comp_element and isinstance(comp_element, dict):
+                comp_pos = comp_element.get("rank_absolute", comp_element.get("rank_group", "N/A"))
+            else:
+                comp_pos = "N/A"
+            
+            print(f"  {keyword},{volume},{difficulty},{comp_pos}")
+    else:
+        print("No keyword gaps found")
+    
+    print()
+    print("Tip: Focus on keywords with high volume and low difficulty where competitor ranks in top 10")
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/seo-geo/scripts/credential.py
+++ b/.agents/skills/seo-geo/scripts/credential.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+"""
+Credential helper for DataForSEO API
+"""
+import os
+
+
+def get_dataforseo_credentials() -> tuple:
+    """Get DataForSEO login and password from environment"""
+    login = os.environ.get("DATAFORSEO_LOGIN")
+    password = os.environ.get("DATAFORSEO_PASSWORD")
+    return login, password

--- a/.agents/skills/seo-geo/scripts/dataforseo_api.py
+++ b/.agents/skills/seo-geo/scripts/dataforseo_api.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""
+DataForSEO API wrapper
+"""
+import urllib.request
+import urllib.parse
+import json
+import base64
+import sys
+from credential import get_dataforseo_credentials
+
+API_BASE = "https://api.dataforseo.com/v3"
+
+
+def api_post(endpoint: str, data: list) -> dict:
+    """Make POST request to DataForSEO API"""
+    login, password = get_dataforseo_credentials()
+    if not login or not password:
+        print("error: DATAFORSEO_LOGIN and DATAFORSEO_PASSWORD not set", file=sys.stderr)
+        print("Run: export DATAFORSEO_LOGIN=your_login", file=sys.stderr)
+        print("     export DATAFORSEO_PASSWORD=your_password", file=sys.stderr)
+        sys.exit(1)
+    
+    url = f"{API_BASE}/{endpoint}"
+    auth = base64.b64encode(f"{login}:{password}".encode()).decode()
+    headers = {
+        "Authorization": f"Basic {auth}",
+        "Content-Type": "application/json"
+    }
+    
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(data).encode(),
+        headers=headers,
+        method="POST"
+    )
+    
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        error_body = e.read().decode()
+        print(f"error: HTTP {e.code} - {error_body}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def format_count(n) -> str:
+    """Format numbers (1234567 -> 1.2M)"""
+    if n is None:
+        return "0"
+    n = int(n)
+    if n >= 1_000_000_000:
+        return f"{n/1_000_000_000:.1f}B"
+    if n >= 1_000_000:
+        return f"{n/1_000_000:.1f}M"
+    if n >= 1_000:
+        return f"{n/1_000:.1f}K"
+    return str(n)
+
+
+def get_result(response: dict) -> list:
+    """Extract result from API response"""
+    if not response.get("tasks"):
+        return []
+    task = response["tasks"][0]
+    if task.get("status_code") != 20000:
+        print(f"error: {task.get('status_message', 'Unknown error')}", file=sys.stderr)
+        return []
+    return task.get("result", [])
+
+
+def print_keywords_list(keywords: list):
+    """Print list of keywords"""
+    print(f"keywords[{len(keywords)}]{{keyword,volume,difficulty}}:")
+    for kw in keywords:
+        keyword = kw.get("keyword", "N/A")
+        volume = format_count(kw.get("search_volume"))
+        difficulty = kw.get("keyword_difficulty", "N/A")
+        print(f"  {keyword},{volume},{difficulty}")
+
+
+def print_serp_list(items: list):
+    """Print SERP results"""
+    organic = [i for i in items if i.get("type") == "organic"]
+    print(f"serp[{len(organic)}]{{position,title,domain}}:")
+    for item in organic[:20]:
+        pos = item.get("rank_absolute", "N/A")
+        title = (item.get("title") or "")[:50]
+        domain = item.get("domain", "N/A")
+        print(f"  {pos},{title},{domain}")
+
+
+def print_backlinks_list(items: list):
+    """Print backlinks"""
+    print(f"backlinks[{len(items)}]{{from,to,rank,dofollow}}:")
+    for item in items:
+        url_from = (item.get("url_from") or "")[:50]
+        url_to = (item.get("url_to") or "")[:30]
+        rank = item.get("rank", "N/A")
+        dofollow = item.get("dofollow", False)
+        print(f"  {url_from},{url_to},{rank},{dofollow}")

--- a/.agents/skills/seo-geo/scripts/domain_overview.py
+++ b/.agents/skills/seo-geo/scripts/domain_overview.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""
+Domain overview using DataForSEO API
+Usage: python3 scripts/domain_overview.py "example.com"
+"""
+import argparse
+from dataforseo_api import api_post, get_result, format_count
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Domain overview")
+    parser.add_argument("domain", help="Target domain")
+    parser.add_argument("--location", "-loc", type=int, default=2840,
+                        help="Location code (default: 2840 = US)")
+    args = parser.parse_args()
+
+    data = [{
+        "target": args.domain,
+        "location_code": args.location,
+        "language_code": "en",
+        "limit": 1  # We only need overview metrics
+    }]
+    
+    response = api_post("dataforseo_labs/google/ranked_keywords/live", data)
+    results = get_result(response)
+    
+    print(f"domain: {args.domain}")
+    print(f"location: {args.location}")
+    
+    if results:
+        for result in results:
+            metrics = result.get("metrics", {})
+            if not metrics:
+                continue
+            organic = metrics.get("organic", {})
+            print(f"organic_keywords: {format_count(organic.get('count', 0))}")
+            print(f"organic_traffic: {format_count(organic.get('etv', 0))}")
+            print(f"top_3_positions: {organic.get('pos_1', 0) + organic.get('pos_2_3', 0)}")
+    else:
+        print("No results found")
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/seo-geo/scripts/keyword_research.py
+++ b/.agents/skills/seo-geo/scripts/keyword_research.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""
+Keyword research using DataForSEO API
+Usage: python3 scripts/keyword_research.py "seo tools" --limit 20
+"""
+import argparse
+from dataforseo_api import api_post, get_result, print_keywords_list
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Keyword research")
+    parser.add_argument("keyword", help="Seed keyword")
+    parser.add_argument("--location", "-loc", type=int, default=2840,
+                        help="Location code (default: 2840 = US)")
+    parser.add_argument("--limit", "-l", type=int, default=20, help="Max results")
+    args = parser.parse_args()
+
+    data = [{
+        "keywords": [args.keyword],  # API requires 'keywords' array (up to 20)
+        "location_code": args.location,
+        "language_code": "en",
+        "limit": args.limit
+    }]
+    
+    response = api_post("keywords_data/google_ads/keywords_for_keywords/live", data)
+    results = get_result(response)
+    
+    print(f"keyword: {args.keyword}")
+    print(f"location: {args.location}")
+    
+    if results:
+        print_keywords_list(results[:args.limit])
+    else:
+        print("No results found")
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/seo-geo/scripts/related_keywords.py
+++ b/.agents/skills/seo-geo/scripts/related_keywords.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""
+Related keywords from Google "searches related to" using DataForSEO API
+Get up to 4,680 keyword ideas from Google's related searches
+
+Usage: python3 scripts/related_keywords.py "AI agent" --depth 2 --limit 50
+"""
+import argparse
+from dataforseo_api import api_post, get_result, format_count
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Related keywords from Google")
+    parser.add_argument("keyword", help="Seed keyword")
+    parser.add_argument("--location", "-loc", type=int, default=2840,
+                        help="Location code (default: 2840 = US)")
+    parser.add_argument("--depth", "-d", type=int, default=1,
+                        help="Search depth 1-3 (default: 1, max keywords: depth^3 * 10)")
+    parser.add_argument("--limit", "-l", type=int, default=50, 
+                        help="Max results to display (default: 50)")
+    args = parser.parse_args()
+
+    # Validate depth
+    if args.depth < 1 or args.depth > 3:
+        print("Error: depth must be between 1 and 3")
+        return
+
+    data = [{
+        "keyword": args.keyword,
+        "location_code": args.location,
+        "language_code": "en",
+        "depth": args.depth,
+        "limit": 1000  # API limit, we'll filter in display
+    }]
+    
+    response = api_post("dataforseo_labs/google/related_keywords/live", data)
+    results = get_result(response)
+    
+    print(f"keyword: {args.keyword}")
+    print(f"location: {args.location}")
+    print(f"depth: {args.depth}")
+    print()
+    
+    if results:
+        keywords = []
+        for result in results:
+            items = result.get("items", [])
+            for item in items:
+                kw_data = item.get("keyword_data", {})
+                keyword = kw_data.get("keyword", item.get("keyword", ""))
+                volume = kw_data.get("search_volume", item.get("search_volume", 0))
+                difficulty = kw_data.get("keyword_difficulty", item.get("keyword_difficulty", "N/A"))
+                
+                if keyword:
+                    keywords.append({
+                        "keyword": keyword,
+                        "volume": volume if volume is not None else 0,
+                        "difficulty": difficulty
+                    })
+        
+        # Sort by volume desc
+        keywords.sort(key=lambda x: x["volume"], reverse=True)
+        
+        # Display limited results
+        display_keywords = keywords[:args.limit]
+        print(f"related_keywords[{len(display_keywords)} of {len(keywords)}]{{keyword,volume,difficulty}}:")
+        for kw in display_keywords:
+            keyword = kw["keyword"]
+            volume = format_count(kw["volume"])
+            difficulty = kw["difficulty"]
+            print(f"  {keyword},{volume},{difficulty}")
+        
+        if len(keywords) > args.limit:
+            print(f"\n... and {len(keywords) - args.limit} more keywords (use --limit to show more)")
+    else:
+        print("No related keywords found")
+    
+    print()
+    print("Tip: Higher depth finds more keywords but costs more API credits")
+    print(f"  Depth 1: ~10 keywords, Depth 2: ~100, Depth 3: ~1,000+")
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/seo-geo/scripts/seo_audit.py
+++ b/.agents/skills/seo-geo/scripts/seo_audit.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""
+SEO audit script (no API required)
+Usage: python3 scripts/seo_audit.py "https://example.com"
+"""
+import argparse
+import urllib.request
+import urllib.parse
+import re
+import time
+import sys
+
+
+def fetch_url(url: str, timeout: int = 30) -> tuple:
+    """Fetch URL and return (content, headers, load_time)"""
+    try:
+        start = time.time()
+        req = urllib.request.Request(url, headers={"User-Agent": "SEO-Audit/1.0"})
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            content = resp.read().decode("utf-8", errors="ignore")
+            headers = dict(resp.headers)
+            load_time = time.time() - start
+            return content, headers, load_time
+    except Exception as e:
+        return None, None, None
+
+
+def extract_meta(html: str) -> dict:
+    """Extract meta tags from HTML"""
+    result = {}
+    
+    # Title
+    title_match = re.search(r"<title[^>]*>([^<]+)</title>", html, re.I)
+    result["title"] = title_match.group(1).strip() if title_match else None
+    
+    # Meta description
+    desc_match = re.search(r'<meta[^>]+name=["\']description["\'][^>]+content=["\']([^"\']+)["\']', html, re.I)
+    if not desc_match:
+        desc_match = re.search(r'<meta[^>]+content=["\']([^"\']+)["\'][^>]+name=["\']description["\']', html, re.I)
+    result["description"] = desc_match.group(1).strip() if desc_match else None
+    
+    # OG tags
+    og_match = re.search(r'<meta[^>]+property=["\']og:title["\']', html, re.I)
+    result["og_tags"] = bool(og_match)
+    
+    # JSON-LD
+    jsonld_count = len(re.findall(r'application/ld\+json', html, re.I))
+    result["jsonld_count"] = jsonld_count
+    
+    # H1 (handle inline tags like <br>)
+    h1_match = re.search(r"<h1[^>]*>(.*?)</h1>", html, re.I | re.DOTALL)
+    if h1_match:
+        h1_text = re.sub(r"<[^>]+>", " ", h1_match.group(1))  # Remove inner tags
+        h1_text = re.sub(r"\s+", " ", h1_text).strip()  # Normalize whitespace
+        result["h1"] = h1_text[:100]
+    else:
+        result["h1"] = None
+    
+    return result
+
+
+def check_robots(url: str) -> dict:
+    """Check robots.txt"""
+    parsed = urllib.parse.urlparse(url)
+    robots_url = f"{parsed.scheme}://{parsed.netloc}/robots.txt"
+    content, _, _ = fetch_url(robots_url)
+    
+    result = {"exists": False, "ai_bots": []}
+    if content:
+        result["exists"] = True
+        ai_bots = ["GPTBot", "PerplexityBot", "ClaudeBot", "anthropic-ai", "ChatGPT-User"]
+        for bot in ai_bots:
+            if bot.lower() in content.lower():
+                result["ai_bots"].append(bot)
+    return result
+
+
+def check_sitemap(url: str) -> bool:
+    """Check if sitemap.xml exists"""
+    parsed = urllib.parse.urlparse(url)
+    sitemap_url = f"{parsed.scheme}://{parsed.netloc}/sitemap.xml"
+    content, _, _ = fetch_url(sitemap_url)
+    if not content:
+        return False
+    # Check for common sitemap indicators
+    return "<urlset" in content.lower() or "<sitemapindex" in content.lower() or "<?xml" in content.lower()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="SEO audit")
+    parser.add_argument("url", help="URL to audit")
+    args = parser.parse_args()
+    
+    url = args.url
+    if not url.startswith("http"):
+        url = f"https://{url}"
+    
+    print(f"=== SEO Audit: {url} ===")
+    print()
+    
+    # Fetch page
+    content, headers, load_time = fetch_url(url)
+    if not content:
+        print("error: Could not fetch URL")
+        sys.exit(1)
+    
+    # Meta tags
+    print("## Meta Tags")
+    meta = extract_meta(content)
+    title = meta["title"]
+    print(f"title: {title[:60] if title else 'MISSING'}{'...' if title and len(title) > 60 else ''}")
+    print(f"title_length: {len(title) if title else 0} chars")
+    desc = meta["description"]
+    print(f"description: {desc[:80] if desc else 'MISSING'}{'...' if desc and len(desc) > 80 else ''}")
+    print(f"description_length: {len(desc) if desc else 0} chars")
+    print(f"og_tags: {'yes' if meta['og_tags'] else 'no'}")
+    print(f"h1: {meta['h1'] if meta['h1'] else 'MISSING'}")
+    print()
+    
+    # Schema
+    print("## Schema Markup")
+    print(f"json_ld_blocks: {meta['jsonld_count']}")
+    print()
+    
+    # Performance
+    print("## Performance")
+    print(f"load_time: {load_time:.2f}s")
+    print(f"status: {'good' if load_time < 3 else 'slow'}")
+    print()
+    
+    # robots.txt
+    print("## robots.txt")
+    robots = check_robots(url)
+    print(f"exists: {'yes' if robots['exists'] else 'no'}")
+    if robots["ai_bots"]:
+        print(f"ai_bots_mentioned: {', '.join(robots['ai_bots'])}")
+    else:
+        print("ai_bots_mentioned: none")
+    print()
+    
+    # Sitemap
+    print("## Sitemap")
+    has_sitemap = check_sitemap(url)
+    print(f"sitemap_xml: {'yes' if has_sitemap else 'no'}")
+    print()
+    
+    print("=== Audit Complete ===")
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/seo-geo/scripts/serp_analysis.py
+++ b/.agents/skills/seo-geo/scripts/serp_analysis.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""
+SERP analysis using DataForSEO API
+Usage: python3 scripts/serp_analysis.py "best seo tools" --depth 20
+"""
+import argparse
+from dataforseo_api import api_post, get_result, print_serp_list, format_count
+
+
+def main():
+    parser = argparse.ArgumentParser(description="SERP analysis")
+    parser.add_argument("keyword", help="Search keyword")
+    parser.add_argument("--location", "-loc", type=int, default=2840,
+                        help="Location code (default: 2840 = US)")
+    parser.add_argument("--depth", "-d", type=int, default=20, help="Search depth")
+    args = parser.parse_args()
+
+    data = [{
+        "keyword": args.keyword,
+        "location_code": args.location,
+        "language_code": "en",
+        "depth": args.depth
+    }]
+    
+    response = api_post("serp/google/organic/live/advanced", data)
+    results = get_result(response)
+    
+    print(f"keyword: {args.keyword}")
+    print(f"location: {args.location}")
+    
+    if results:
+        result = results[0]
+        print(f"total_results: {format_count(result.get('se_results_count'))}")
+        items = result.get("items", [])
+        print_serp_list(items)
+    else:
+        print("No results found")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/ai-seo
+++ b/.claude/skills/ai-seo
@@ -1,0 +1,1 @@
+../../.agents/skills/ai-seo

--- a/.claude/skills/programmatic-seo
+++ b/.claude/skills/programmatic-seo
@@ -1,0 +1,1 @@
+../../.agents/skills/programmatic-seo

--- a/.claude/skills/seo-audit
+++ b/.claude/skills/seo-audit
@@ -1,0 +1,1 @@
+../../.agents/skills/seo-audit

--- a/.claude/skills/seo-geo
+++ b/.claude/skills/seo-geo
@@ -1,0 +1,1 @@
+../../.agents/skills/seo-geo

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,25 @@
+{
+  "version": 1,
+  "skills": {
+    "ai-seo": {
+      "source": "coreyhaines31/marketingskills",
+      "sourceType": "github",
+      "computedHash": "5f7ce5ccdb2b0dce5e1ea7f3ed8bf17070b790865e91725ca8908e6ec829e164"
+    },
+    "programmatic-seo": {
+      "source": "coreyhaines31/marketingskills",
+      "sourceType": "github",
+      "computedHash": "40b8fe29a6c9cb0606e6fa77aff227cf275e3808adf66e5ef69e02dcf60a7303"
+    },
+    "seo-audit": {
+      "source": "coreyhaines31/marketingskills",
+      "sourceType": "github",
+      "computedHash": "ec3109d213dde1747614ad1112ef0e498e04b24e464538968e156dfbfadb2121"
+    },
+    "seo-geo": {
+      "source": "resciencelab/opc-skills",
+      "sourceType": "github",
+      "computedHash": "56f90ba46b36563bb5461feb8462aed9283e74dfc4cdac2a98c42c4bc86a95be"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add 4 SEO skills installed via `npx skills add` for ongoing SEO optimization
- **seo-audit**: Page-level technical + on-page SEO auditing with E-E-A-T checks
- **programmatic-seo**: 12 playbooks for building SEO pages at scale
- **ai-seo**: Generative Engine Optimization for AI citation (ChatGPT, Perplexity, Google AI Overviews)
- **seo-geo**: Combined SEO + GEO workflow with platform-specific optimization

## Test plan
- [ ] Skills are accessible via Claude Code in the project
- [ ] Symlinks in `.claude/skills/` resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)