### PR TITLE
fix: resolve TypeScript errors and missing Recipe Microdata image

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -52,7 +52,7 @@ const categoryBasePath = locale === "fr" ? "/fr/recettes/categorie/" : "/en/reci
       <!-- Brand -->
       <div class="sm:col-span-2 lg:col-span-1">
         <a href={getLocalizedPath(locale, "/")} class="inline-block no-underline">
-          <img src={inlineLogo.src} class="h-8" alt="Date My Dish" width={inlineLogo.width} height={inlineLogo.height} data-pin-nopin="true" />
+          <img src={inlineLogo.src} class="h-8" alt="Date My Dish" width={inlineLogoSrc.width} height={inlineLogoSrc.height} data-pin-nopin="true" />
         </a>
         <p class="mt-3 text-body-sm text-neutral-600 dark:text-neutral-400">
           {t(locale, "footer.madeWith")}

--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -37,7 +37,7 @@ function isActive(linkPath: string): boolean {
     <!-- Logo -->
     <a href={getLocalizedPath(locale, "/")} class="flex items-center gap-2.5 no-underline hover:opacity-80">
       <img src="/favicon.svg" class="h-8 w-8" alt="" width="32" height="32" data-pin-nopin="true" />
-      <img src={inlineLogo.src} class="hidden h-8 lg:block lg:h-10" alt="Date My Dish" width={inlineLogo.width} height={inlineLogo.height} data-pin-nopin="true" />
+      <img src={inlineLogo.src} class="hidden h-8 lg:block lg:h-10" alt="Date My Dish" width={inlineLogoSrc.width} height={inlineLogoSrc.height} data-pin-nopin="true" />
     </a>
 
     <!-- Desktop Nav -->

--- a/src/components/RecipeDetailCard.astro
+++ b/src/components/RecipeDetailCard.astro
@@ -74,6 +74,7 @@ const {
       class="h-56 w-full object-cover sm:h-72"
       loading="lazy"
       data-pin-nopin="true"
+      itemprop="image"
     />
   </div>
 

--- a/tests/smoke/recipe-schema.spec.ts
+++ b/tests/smoke/recipe-schema.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect } from "../fixtures";
+import { discoverPages } from "../helpers/discover-pages";
+
+const recipePages = discoverPages().filter(
+  (p) =>
+    (p.path.startsWith("/en/recipes/") || p.path.startsWith("/fr/recettes/")) &&
+    // Exclude listing/category/tag/occasion/cuisine pages
+    p.path.split("/").filter(Boolean).length >= 3 &&
+    !p.path.includes("/category/") &&
+    !p.path.includes("/categorie/") &&
+    !p.path.includes("/tag/") &&
+    !p.path.includes("/etiquette/") &&
+    !p.path.includes("/occasion/") &&
+    !p.path.includes("/cuisine/"),
+);
+
+for (const { path, name } of recipePages) {
+  test(`${name} has valid Recipe Microdata`, async ({ page }) => {
+    await page.goto(path);
+
+    const card = page.locator('article[itemtype="https://schema.org/Recipe"]');
+    await expect(card, `${path} missing Recipe itemscope`).toHaveCount(1);
+
+    // Required Microdata properties for Google rich results
+    await expect(
+      card.locator('[itemprop="image"]'),
+      `${path} missing itemprop="image"`,
+    ).toHaveCount(1);
+
+    await expect(
+      card.locator('[itemprop="name"]'),
+      `${path} missing itemprop="name"`,
+    ).toHaveCount(1);
+
+    await expect(
+      card.locator('[itemprop="recipeIngredient"]'),
+      `${path} missing itemprop="recipeIngredient"`,
+    ).not.toHaveCount(0);
+
+    await expect(
+      card.locator('[itemprop="recipeInstructions"]'),
+      `${path} missing itemprop="recipeInstructions"`,
+    ).not.toHaveCount(0);
+  });
+
+  test(`${name} has valid Recipe JSON-LD`, async ({ page }) => {
+    await page.goto(path);
+
+    const jsonLd = await page.evaluate(() => {
+      const scripts = document.querySelectorAll(
+        'script[type="application/ld+json"]',
+      );
+      for (const script of scripts) {
+        try {
+          const data = JSON.parse(script.textContent || "");
+          if (data["@type"] === "Recipe") return data;
+        } catch {
+          // skip malformed
+        }
+      }
+      return null;
+    });
+
+    expect(jsonLd, `${path} missing Recipe JSON-LD`).not.toBeNull();
+    expect(jsonLd.image, `${path} JSON-LD missing image`).toBeTruthy();
+    expect(jsonLd.image.length, `${path} JSON-LD image is empty array`).toBeGreaterThan(0);
+    expect(jsonLd.name, `${path} JSON-LD missing name`).toBeTruthy();
+    expect(jsonLd.recipeIngredient?.length, `${path} JSON-LD missing ingredients`).toBeGreaterThan(0);
+    expect(jsonLd.recipeInstructions?.length, `${path} JSON-LD missing instructions`).toBeGreaterThan(0);
+    expect(jsonLd.description, `${path} JSON-LD missing description`).toBeTruthy();
+    expect(jsonLd.author, `${path} JSON-LD missing author`).toBeTruthy();
+    expect(jsonLd.recipeCategory, `${path} JSON-LD missing recipeCategory`).toBeTruthy();
+    expect(jsonLd.recipeCuisine, `${path} JSON-LD missing recipeCuisine`).toBeTruthy();
+    expect(jsonLd.keywords, `${path} JSON-LD missing keywords`).toBeTruthy();
+  });
+}


### PR DESCRIPTION
## Summary
- Fix TypeScript errors in `Footer.astro` and `Navigation.astro` by using `inlineLogoSrc.width/height` instead of `inlineLogo.width/height` (`GetImageResult` doesn't have these properties)
- Add `itemprop="image"` to `RecipeDetailCard.astro` hero image to fix Google Search Console "Missing field 'image'" Microdata error
- Add Playwright E2E tests validating Recipe Microdata and JSON-LD completeness on all recipe pages

## Test plan
- [x] `npm run check` passes with 0 errors
- [x] `npm run build` succeeds
- [x] All 192 recipe schema E2E tests pass (24 pages x 2 checks x 4 projects)
- [ ] Validate fix in Google Search Console after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)