### PR TITLE
fix(seo): weekly maintenance - 2026-04-26

### DIFF
--- a/src/content/articles/en/why-not-wash-chicken.mdx
+++ b/src/content/articles/en/why-not-wash-chicken.mdx
@@ -2,7 +2,7 @@
 title: "Why You Shouldn't Wash Chicken"
 lang: en
 translationSlug: "pourquoi-ne-pas-laver-le-poulet"
-description: "Rinsing raw chicken launches bacteria across your kitchen. Learn the science behind skipping the rinse, the safe alternative, and why it matters for date night."
+description: "Washing raw chicken spreads bacteria across your kitchen. The food safety science behind skipping the rinse, and why it leads to better date night cooking."
 author: "Victor"
 publishDate: 2026-02-27
 updatedDate: 2026-03-09

--- a/src/content/articles/fr/pourquoi-ne-pas-laver-le-poulet.mdx
+++ b/src/content/articles/fr/pourquoi-ne-pas-laver-le-poulet.mdx
@@ -2,7 +2,7 @@
 title: "Pourquoi ne pas laver le poulet"
 lang: fr
 translationSlug: "why-not-wash-chicken"
-description: "Rincer le poulet cru propage les bacteries dans votre cuisine. Decouvrez pourquoi eviter ce reflexe, l'alternative securitaire et son importance pour un souper en amoureux."
+description: "Rincer le poulet cru propage les bacteries dans votre cuisine. Decouvrez pourquoi eviter ce reflexe et l'alternative pour un souper en amoureux reussi."
 author: "Victor"
 publishDate: 2026-02-27
 updatedDate: 2026-03-09

--- a/src/content/recipes/en/crispy-vegan-calamari.mdx
+++ b/src/content/recipes/en/crispy-vegan-calamari.mdx
@@ -2,7 +2,7 @@
 title: "Crispy Vegan Calamari Recipe"
 lang: en
 translationSlug: "calamars-vegetaliens-croustillants"
-description: "Oyster mushroom calamari that fooled my last dinner party. King oyster mushrooms fried in an oregano-cayenne batter. Crispy, chewy, completely plant-based."
+description: "Crispy vegan calamari made with king oyster mushrooms in an oregano-cayenne batter. Ready in 30 minutes, plant-based, and convincing enough to fool meat eaters."
 author: "Victor"
 publishDate: 2025-05-10
 updatedDate: 2026-03-09

--- a/src/content/recipes/en/quinoa-crusted-salmon.mdx
+++ b/src/content/recipes/en/quinoa-crusted-salmon.mdx
@@ -2,7 +2,7 @@
 title: "Quinoa-Crusted Salmon, Miso Sauce"
 lang: en
 translationSlug: "saumon-en-croute-de-quinoa"
-description: "Quinoa crusted salmon with a spicy orange miso glaze. Crispy crust, tender center, ready in 40 minutes. The Nikkei fusion recipe that earns second helpings."
+description: "Quinoa-crusted salmon with spicy orange miso glaze. Crispy outside, tender inside, ready in 40 minutes. The Nikkei fusion date night recipe guests love."
 author: "Victor"
 publishDate: 2025-06-05
 updatedDate: 2026-03-12

--- a/src/content/recipes/fr/calamars-vegetaliens-croustillants.mdx
+++ b/src/content/recipes/fr/calamars-vegetaliens-croustillants.mdx
@@ -2,7 +2,7 @@
 title: "Calamars végétaliens croustillants"
 lang: fr
 translationSlug: "crispy-vegan-calamari"
-description: "Calamars aux pleurotes royaux dans une pâte à l'origan et cayenne. Croustillants, véganes, prêts en 30 min. La recette qui trompe tout le monde à table."
+description: "Calamars véganes croustillants aux pleurotes royaux, panés à l'origan et au cayenne. Prêts en 30 minutes, véganes à 100 % et si convaincants à table."
 author: "Victor"
 publishDate: 2025-05-10
 updatedDate: 2026-03-09

--- a/src/content/recipes/fr/saumon-en-croute-de-quinoa.mdx
+++ b/src/content/recipes/fr/saumon-en-croute-de-quinoa.mdx
@@ -2,7 +2,7 @@
 title: "Saumon en croûte de quinoa, miso"
 lang: fr
 translationSlug: "quinoa-crusted-salmon"
-description: "Saumon croûte de quinoa, glaçage miso épicé à l'orange, prêt en 40 min. Croustillant dehors, tendre dedans. La fusion Nikkei qu'on refait chaque semaine."
+description: "Saumon en croûte de quinoa, glaçage miso épicé à l'orange. Croustillant dehors, tendre dedans, prêt en 40 min. La fusion Nikkei pour un souper en amoureux."
 author: "Victor"
 publishDate: 2025-06-05
 updatedDate: 2026-03-12


### PR DESCRIPTION
Automated weekly SEO maintenance.

## Changes

**Audit fix:**
- Shortened FR article description for `pourquoi-ne-pas-laver-le-poulet` from 172 to 151 chars (was over the 160-char limit)

**Underperformer optimization** (3 pages from `rankings-2026-04-20.json` + `rankings-2026-04-13.json`):
- `crispy-vegan-calamari` (avg pos 63.7, 0 clicks): front-loaded "crispy vegan calamari" keyword in EN + FR descriptions
- `quinoa-crusted-salmon` (avg pos 20.4, 0 clicks): added date night framing and cleaner sentence structure in EN + FR
- `why-not-wash-chicken` article (avg pos 11.3, 0 clicks): swapped to "Washing" (matches search intent) and added "food safety science" keyword signal in EN

**Internal links:** skipped (no new content merged to main in the last 7 days)

All descriptions validated with `node scripts/validate-descriptions.mjs` (120-160 chars).

---
_Generated by [Claude Code](https://claude.ai/code/session_01RWPKVx39Ca2Cx9yruzf36r)_