### PR TITLE
fix(seo): weekly maintenance - 2026-05-10

### DIFF
--- a/src/content/articles/en/perfect-steak-date-night-guide.mdx
+++ b/src/content/articles/en/perfect-steak-date-night-guide.mdx
@@ -113,7 +113,7 @@ The surface of a steak that's been slowly oven-dried is almost perfectly dry bef
 
 ## Temperature guide: the only thing that matters
 
-Stop guessing. Get a thermometer. It costs about 15 dollars and eliminates the single biggest source of steak anxiety.
+Stop guessing. Get a thermometer. It costs about 15 dollars and eliminates the single biggest source of steak anxiety. It's the first tool in our [cooking essentials starter kit](/en/articles/cooking-essentials-starter-kit/) for this exact reason.
 
 Rare (120 to 125°F): cool red center, maximum tenderness, maximum juiciness. Not for everyone, but worth trying once with a good cut to understand what the ingredient actually is.
 

--- a/src/content/articles/en/the-foolproof-egg-formula.mdx
+++ b/src/content/articles/en/the-foolproof-egg-formula.mdx
@@ -56,7 +56,7 @@ import softBoiledImg from "../../../assets/images/articles/the-foolproof-egg-for
 
 There is one cooking test that professional kitchens still use in job interviews: cook eggs. Not braised short ribs, not a sauce requiring hours of classical training. Just eggs. The simplest, cheapest ingredient in the kitchen, and the one that exposes exactly how much control you have over heat, timing, and patience. Chefs pick this test for a reason. Eggs don't lie.
 
-For a morning-after breakfast or a weekend brunch date, perfectly cooked eggs land differently. They show that you cook with intention, not just for sustenance. The difference between rubbery scrambled eggs and a plate of silky, glossy curds tells your date everything about your kitchen confidence, without a word. This is the foolproof egg formula: four methods, four principles, and every common mistake mapped out so you stop guessing.
+For a morning-after breakfast or a weekend brunch date, perfectly cooked eggs land differently. They show that you cook with intention, not just for sustenance. The difference between rubbery scrambled eggs and a plate of silky, glossy curds tells your date everything about your [kitchen confidence](/en/articles/cooking-essentials-starter-kit/), without a word. This is the foolproof egg formula: four methods, four principles, and every common mistake mapped out so you stop guessing.
 
 ## Why eggs are the hardest easy thing to cook
 

--- a/src/content/articles/en/why-not-wash-chicken.mdx
+++ b/src/content/articles/en/why-not-wash-chicken.mdx
@@ -95,7 +95,7 @@ Sanitize every surface the raw chicken touched: cutting board, knife, countertop
 
 165°F. That is it. That is the internal temperature at which every harmful bacterium on raw chicken is eliminated.
 
-Use an instant-read thermometer in the thickest part of the meat, away from the bone. Check multiple pieces if you are cooking more than one. Let the chicken rest for three minutes after it hits temperature; the internal temp keeps climbing slightly and finishes the job. A good instant-read thermometer costs under twenty dollars and is genuinely one of the most useful things in a home kitchen.
+Use an instant-read thermometer in the thickest part of the meat, away from the bone. Check multiple pieces if you are cooking more than one. Let the chicken rest for three minutes after it hits temperature; the internal temp keeps climbing slightly and finishes the job. A good instant-read thermometer costs under twenty dollars and is genuinely one of the most useful things in a home kitchen, right up there with the other tools in our [cooking essentials starter kit](/en/articles/cooking-essentials-starter-kit/).
 
 This is exactly why washing is unnecessary. Proper cooking eliminates any surface bacteria completely. Washing only adds risk without providing any benefit.
 

--- a/src/content/articles/en/why-not-wash-chicken.mdx
+++ b/src/content/articles/en/why-not-wash-chicken.mdx
@@ -2,7 +2,7 @@
 title: "Why You Shouldn't Wash Chicken"
 lang: en
 translationSlug: "pourquoi-ne-pas-laver-le-poulet"
-description: "Washing raw chicken spreads bacteria across your kitchen. The food safety science behind skipping the rinse, and why it leads to better date night cooking."
+description: "Washing chicken splashes Salmonella across your kitchen. The USDA says skip the rinse. Here's the food safety science and why your cooking improves without it."
 author: "Victor"
 publishDate: 2026-02-27
 updatedDate: 2026-03-09

--- a/src/content/articles/fr/pourquoi-ne-pas-laver-le-poulet.mdx
+++ b/src/content/articles/fr/pourquoi-ne-pas-laver-le-poulet.mdx
@@ -2,7 +2,7 @@
 title: "Pourquoi ne pas laver le poulet"
 lang: fr
 translationSlug: "why-not-wash-chicken"
-description: "Rincer le poulet cru propage les bactéries partout dans la cuisine. Découvrez pourquoi éviter ce réflexe et comment préparer la volaille sans risque."
+description: "Rincer le poulet cru éclabousse la Salmonella dans toute la cuisine. L'USDA recommande d'éviter ce geste. Voici la science et comment cuisiner sans risque."
 author: "Victor"
 publishDate: 2026-02-27
 updatedDate: 2026-03-09

--- a/src/content/recipes/en/crispy-vegan-calamari.mdx
+++ b/src/content/recipes/en/crispy-vegan-calamari.mdx
@@ -2,7 +2,7 @@
 title: "Crispy Vegan Calamari Recipe"
 lang: en
 translationSlug: "calamars-vegetaliens-croustillants"
-description: "King oyster mushroom calamari fried in an oregano-cayenne batter. Vegan, ready in 30 minutes, and so convincing even seafood fans ask for seconds."
+description: "Vegan calamari that actually fools seafood fans. King oyster mushroom rings fried crispy in an oregano-cayenne batter, ready in 30 minutes."
 author: "Victor"
 publishDate: 2025-05-10
 updatedDate: 2026-03-09

--- a/src/content/recipes/fr/calamars-vegetaliens-croustillants.mdx
+++ b/src/content/recipes/fr/calamars-vegetaliens-croustillants.mdx
@@ -2,7 +2,7 @@
 title: "Calamars végétaliens croustillants"
 lang: fr
 translationSlug: "crispy-vegan-calamari"
-description: "Calamars véganes aux pleurotes royaux, frits dans une panure à l'origan et au cayenne. Prêts en 30 minutes. Même les amateurs de fruits de mer en redemandent."
+description: "Calamars véganes qui bluffent même les amateurs de fruits de mer. Pleurotes royaux frits dans une panure à l'origan et au cayenne, prêts en 30 minutes."
 author: "Victor"
 publishDate: 2025-05-10
 updatedDate: 2026-03-09


### PR DESCRIPTION
Automated weekly SEO maintenance.

## Changes

**Optimize underperforming content** (2 pages with impressions, 0 clicks in rankings-2026-05-04):
- `crispy-vegan-calamari` EN+FR: rewrote description to lead with "vegan calamari" keyword (best pos 21 for oyster mushroom calamari queries)
- `why-not-wash-chicken` EN+FR: rewrote description to front-load Salmonella/USDA signal (best pos 11)

**Add internal links** (new `cooking-essentials-starter-kit` article from May 4):
- `the-foolproof-egg-formula`: linked "kitchen confidence" anchor to cooking essentials
- `why-not-wash-chicken`: linked thermometer mention to cooking essentials
- `perfect-steak-date-night-guide`: linked thermometer section to cooking essentials

https://claude.ai/code/session_01QH6j7nkuFFS2v8sD2zUwmq

---
_Generated by [Claude Code](https://claude.ai/code/session_01QH6j7nkuFFS2v8sD2zUwmq)_