### PR TITLE
fix(seo): weekly maintenance - 2026-06-07

### DIFF
--- a/src/content/articles/en/cooking-essentials-starter-kit.mdx
+++ b/src/content/articles/en/cooking-essentials-starter-kit.mdx
@@ -92,7 +92,7 @@ The Victorinox Fibrox is the knife culinary schools hand to first-year students.
 
 A big board makes everything calmer. You can prep without ingredients falling off the edge every 10 seconds, and your knife stays sharper longer on a proper surface. Flimsy boards slide around, dull your blade, and make prep feel like punishment.
 
-What to look for: a big surface, a stable grip (or just put a damp towel underneath for zero sliding), and easy cleanup. If it smells like garlic forever, scrub with salt and lemon. The OXO Good Grips board checks every box. Non-slip feet, a juice groove for catching liquids, and it is dishwasher-safe. It will not warp on you after six months like the cheap bamboo ones.
+What to look for: a big surface, a stable grip (or just put a damp towel underneath for zero sliding), and easy cleanup. If it smells like garlic forever, scrub with salt and lemon. The OXO Good Grips board checks every box. Non-slip feet, a juice groove for catching liquids, and it is dishwasher-safe. It will not warp on you after six months like the cheap bamboo ones. If you want to go deeper, our [cutting board material guide](/en/articles/best-cutting-board-material/) breaks down every surface worth considering.
 
 <ProductCard name="OXO Good Grips Large Cutting Board" url="https://amzn.to/41nsvN9" description="Low-maintenance, non-slip cutting board" locale="en" />
 

--- a/src/content/articles/en/perfect-steak-date-night-guide.mdx
+++ b/src/content/articles/en/perfect-steak-date-night-guide.mdx
@@ -101,7 +101,7 @@ Preheat the pan over high heat for a full five minutes. Add 1 to 2 tablespoons o
 
 Flip once. Sear the second side three to four minutes. In the last two minutes, add two tablespoons of butter, two smashed garlic cloves, and a sprig of thyme. Tilt the pan and baste the steak repeatedly with the foaming butter. This is the moment your kitchen smells like a restaurant, and it is entirely intentional. Let your date watch from a safe distance. The sizzle, the steam, the herb-scented butter: it's a performance worth watching, and the confidence you project while doing it reads clearly across the room.
 
-Pull the steak when the thermometer reads 5 degrees below your target temperature, rest it on a cutting board for 5 to 10 minutes loosely tented with foil, and serve. The internal temperature will climb another 5 degrees during rest. For most cuts and most people, pull at 130°F and you'll land at medium-rare, the sweet spot where marbling does its best work.
+Pull the steak when the thermometer reads 5 degrees below your target temperature, rest it on a [cutting board](/en/articles/best-cutting-board-material/) for 5 to 10 minutes loosely tented with foil, and serve. The internal temperature will climb another 5 degrees during rest. For most cuts and most people, pull at 130°F and you'll land at medium-rare, the sweet spot where marbling does its best work.
 
 ## The reverse sear: more control for thick steaks
 

--- a/src/content/articles/en/the-ultimate-guide-to-crafting-the-perfect-cocktail-for-date-night.mdx
+++ b/src/content/articles/en/the-ultimate-guide-to-crafting-the-perfect-cocktail-for-date-night.mdx
@@ -2,7 +2,7 @@
 title: "The Perfect Date Night Cocktail Guide"
 lang: en
 translationSlug: "guide-cocktail-parfait-soiree-romantique"
-description: "Date night cocktails made simple. Master balance, technique, and three impressive recipes: gin martini, whiskey sour, and mojito for a perfect evening at home."
+description: "Master date night cocktails at home: three recipes with clear technique, from a classic gin martini to a whiskey sour, for an impressive evening."
 author: "Victor"
 publishDate: 2026-04-15
 heroImage: "../../../assets/images/articles/the-ultimate-guide-to-crafting-the-perfect-cocktail-for-date-night.webp"

--- a/src/content/articles/en/wok-hei-at-home.mdx
+++ b/src/content/articles/en/wok-hei-at-home.mdx
@@ -85,7 +85,7 @@ If you have outdoor space and you're serious about stir-frying, a portable propa
 
 The gear is non-negotiable. You need a 14-inch round-bottom carbon steel wok, a wok ring to stabilize it on the burner, a metal spatula for tossing and scraping, and complete mise en place with everything prepped before cooking starts.
 
-Preparation matters as much as heat. Cut all ingredients to uniform sizes so they cook evenly. Pat proteins completely dry with paper towels, because any surface moisture drops the wok temperature and blocks browning. Mix your sauce and have it ready. Arrange everything within arm's reach of the stove, ordered from longest to shortest cook time. Once the wok is hot, there is no stopping to chop or measure.
+Preparation matters as much as heat. Cut all ingredients to uniform sizes so they cook evenly on a large, stable [cutting board](/en/articles/best-cutting-board-material/). Pat proteins completely dry with paper towels, because any surface moisture drops the wok temperature and blocks browning. Mix your sauce and have it ready. Arrange everything within arm's reach of the stove, ordered from longest to shortest cook time. Once the wok is hot, there is no stopping to chop or measure.
 
 The golden rule: never stop moving the food. Constant motion prevents burning while building char. A still wok produces a sad stir-fry.
 

--- a/src/content/articles/fr/essentiels-cuisine-kit-depart.mdx
+++ b/src/content/articles/fr/essentiels-cuisine-kit-depart.mdx
@@ -92,7 +92,7 @@ Le Victorinox Fibrox, c'est le couteau que les écoles culinaires donnent aux é
 
 Une grande planche, ça rend tout plus calme. Vous pouvez préparer sans que les ingrédients tombent du bord aux 10 secondes, et votre couteau reste aiguisé plus longtemps sur une surface adéquate. Les planches cheap glissent partout, émoussent votre lame et rendent la préparation pénible.
 
-Quoi chercher : une grande surface, une bonne stabilité (ou mettez juste un linge humide en dessous pour zéro glissement) et un nettoyage facile. Si elle sent l'ail pour l'éternité, frottez avec du sel et du citron. La planche OXO Good Grips coche toutes les cases. Des pattes antidérapantes, une rigole pour attraper les jus, et elle passe au lave-vaisselle. Elle ne gauchira pas après six mois comme les planches de bambou bon marché.
+Quoi chercher : une grande surface, une bonne stabilité (ou mettez juste un linge humide en dessous pour zéro glissement) et un nettoyage facile. Si elle sent l'ail pour l'éternité, frottez avec du sel et du citron. La planche OXO Good Grips coche toutes les cases. Des pattes antidérapantes, une rigole pour attraper les jus, et elle passe au lave-vaisselle. Elle ne gauchira pas après six mois comme les planches de bambou bon marché. Pour aller plus loin, notre [guide des matériaux de planche à découper](/fr/articles/quel-materiau-planche-a-decouper/) passe en revue toutes les options.
 
 <ProductCard name="OXO Good Grips grande planche à découper" url="https://amzn.to/41nsvN9" description="Planche antidérapante, facile d'entretien" locale="fr" />
 

--- a/src/content/articles/fr/guide-cocktail-parfait-soiree-romantique.mdx
+++ b/src/content/articles/fr/guide-cocktail-parfait-soiree-romantique.mdx
@@ -2,7 +2,7 @@
 title: "Cocktails parfaits pour un souper romantique"
 lang: fr
 translationSlug: "the-ultimate-guide-to-crafting-the-perfect-cocktail-for-date-night"
-description: "Cocktails pour souper romantique: l'équilibre, la technique et trois recettes impressionnantes, martini gin, whiskey sour et mojito, pour une soirée parfaite."
+description: "Maîtrisez les cocktails pour souper romantique. Trois recettes avec technique: martini gin, whiskey sour et mojito pour une soirée vraiment impressionnante."
 author: "Victor"
 publishDate: 2026-04-15
 heroImage: "../../../assets/images/articles/the-ultimate-guide-to-crafting-the-perfect-cocktail-for-date-night.webp"

--- a/src/content/articles/fr/guide-steak-parfait-souper-amoureux.mdx
+++ b/src/content/articles/fr/guide-steak-parfait-souper-amoureux.mdx
@@ -101,7 +101,7 @@ Préchauffe la poêle à feu vif pendant cinq minutes complètes. Ajoute 15 à 3
 
 Retourne une seule fois. Saisis le deuxième côté trois à quatre minutes. Dans les deux dernières minutes, ajoute deux cuillères à soupe de beurre, deux gousses d'ail écrasées et un brin de thym. Incline la poêle et arrose le steak répétitivement avec le beurre mousseux. C'est à ce moment que ta cuisine sent comme un restaurant, et c'est entièrement intentionnel. Laisse ton ou ta date observer à distance sécuritaire. Le grésillement, la vapeur, le beurre parfumé aux herbes: c'est un spectacle qui vaut la peine d'être vu, et la confiance que tu projettes pendant que tu le fais se lit clairement de l'autre côté de la cuisine.
 
-Retire le steak quand le thermomètre indique 3°C en dessous de ta cible, laisse-le reposer sur une planche à découper 5 à 10 minutes sous une tente de papier d'aluminium, puis sers. La température interne va encore monter de 3°C pendant le repos. Pour la plupart des coupes et des gens, retire à 54°C et tu atterriras à mi-saignant, le point idéal où le persillage fait son meilleur travail.
+Retire le steak quand le thermomètre indique 3°C en dessous de ta cible, laisse-le reposer sur une [planche à découper](/fr/articles/quel-materiau-planche-a-decouper/) 5 à 10 minutes sous une tente de papier d'aluminium, puis sers. La température interne va encore monter de 3°C pendant le repos. Pour la plupart des coupes et des gens, retire à 54°C et tu atterriras à mi-saignant, le point idéal où le persillage fait son meilleur travail.
 
 ## Le reverse sear: plus de contrôle pour les steaks épais
 

--- a/src/content/articles/fr/wok-hei-a-la-maison.mdx
+++ b/src/content/articles/fr/wok-hei-a-la-maison.mdx
@@ -85,7 +85,7 @@ Si t'as un espace extérieur et que t'es sérieux pour les sautés, un brûleur 
 
 Le matériel est non négociable. Il te faut un wok en acier carbone à fond rond de 14 pouces, un anneau de wok pour le stabiliser sur le brûleur, une spatule en métal pour remuer et racler, et une mise en place complète avec tout préparé avant de commencer la cuisson.
 
-La préparation compte autant que la chaleur. Coupe tous les ingrédients en morceaux de taille uniforme pour qu'ils cuisent de manière égale. Éponge les protéines complètement avec du papier essuie-tout, parce que toute humidité de surface fait chuter la température du wok et bloque le brunissement. Mélange ta sauce et tiens-la prête. Dispose tout à portée de bras du poêle, dans l'ordre du plus long au plus court temps de cuisson. Une fois que le wok est chaud, il n'y a plus d'arrêt pour couper ou mesurer.
+La préparation compte autant que la chaleur. Coupe tous les ingrédients en morceaux de taille uniforme sur une grande [planche à découper](/fr/articles/quel-materiau-planche-a-decouper/) stable pour qu'ils cuisent de manière égale. Éponge les protéines complètement avec du papier essuie-tout, parce que toute humidité de surface fait chuter la température du wok et bloque le brunissement. Mélange ta sauce et tiens-la prête. Dispose tout à portée de bras du poêle, dans l'ordre du plus long au plus court temps de cuisson. Une fois que le wok est chaud, il n'y a plus d'arrêt pour couper ou mesurer.
 
 La règle d'or : n'arrête jamais de bouger la nourriture. Le mouvement constant prévient les brûlures tout en construisant la carbonisation. Un wok immobile produit un sauté triste.
 

--- a/src/content/recipes/en/crispy-vegan-calamari.mdx
+++ b/src/content/recipes/en/crispy-vegan-calamari.mdx
@@ -2,7 +2,7 @@
 title: "Crispy Vegan Calamari Recipe"
 lang: en
 translationSlug: "calamars-vegetaliens-croustillants"
-description: "King oyster mushroom calamari fried in an oregano-cayenne batter. Vegan, ready in 30 minutes, and so convincing even seafood fans ask for seconds."
+description: "Vegan calamari made with king oyster mushrooms in a spiced oregano-cayenne batter. Crispy enough to fool seafood fans and on the table in 30 minutes."
 author: "Victor"
 publishDate: 2025-05-10
 updatedDate: 2026-03-09

--- a/src/content/recipes/en/quinoa-crusted-salmon.mdx
+++ b/src/content/recipes/en/quinoa-crusted-salmon.mdx
@@ -2,7 +2,7 @@
 title: "Quinoa-Crusted Salmon, Miso Sauce"
 lang: en
 translationSlug: "saumon-en-croute-de-quinoa"
-description: "Quinoa-crusted salmon with spicy orange miso glaze. Nikkei fusion for two: crispy crust, silky fish, and the date night recipe worth repeating."
+description: "Quinoa-crusted salmon with a spicy orange miso glaze: a Nikkei recipe delivering a shatteringly crispy crust and silky fish in under 45 minutes for two."
 author: "Victor"
 publishDate: 2025-06-05
 updatedDate: 2026-03-12

--- a/src/content/recipes/fr/calamars-vegetaliens-croustillants.mdx
+++ b/src/content/recipes/fr/calamars-vegetaliens-croustillants.mdx
@@ -2,7 +2,7 @@
 title: "Calamars végétaliens croustillants"
 lang: fr
 translationSlug: "crispy-vegan-calamari"
-description: "Calamars véganes aux pleurotes royaux, frits dans une panure à l'origan et au cayenne. Prêts en 30 minutes. Même les amateurs de fruits de mer en redemandent."
+description: "Calamars végétaliens aux pleurotes royaux frits dans une panure origan-cayenne. Croustillants, végétaliens, prêts en 30 minutes, et convaincants pour tous."
 author: "Victor"
 publishDate: 2025-05-10
 updatedDate: 2026-03-09

--- a/src/content/recipes/fr/saumon-en-croute-de-quinoa.mdx
+++ b/src/content/recipes/fr/saumon-en-croute-de-quinoa.mdx
@@ -2,7 +2,7 @@
 title: "Saumon en croûte de quinoa, miso"
 lang: fr
 translationSlug: "quinoa-crusted-salmon"
-description: "Saumon en croûte de quinoa, glaçage miso épicé à l'orange. Fusion Nikkei pour deux: croustillant, soyeux, prêt en 40 minutes. La recette qu'on refait."
+description: "Saumon en croûte de quinoa avec glaçage miso épicé à l'orange. Fusion Nikkei pour deux: croûte ultra-croustillante, poisson soyeux, prêt en 40 minutes."
 author: "Victor"
 publishDate: 2025-06-05
 updatedDate: 2026-03-12


### PR DESCRIPTION
Automated weekly SEO maintenance.

## Changes

### Optimized underperforming content (3 pages)
Based on `data/seo/rankings-2026-06-01.json`:

- **crispy-vegan-calamari** (pos ~62, 16 impressions): description rewritten to front-load "vegan calamari" for target keyword alignment (EN + FR)
- **quinoa-crusted-salmon** (pos ~21, 11 impressions): description tightened to reinforce "quinoa-crusted salmon recipe" signal (EN + FR)
- **the-ultimate-guide-to-crafting-the-perfect-cocktail-for-date-night** (pos ~25, 4 impressions): description restructured to lead with "date night cocktails at home" (EN + FR)

All descriptions validated within 120-160 char range.

### Internal links to new content (3 links)
New article `best-cutting-board-material` (published Jun 1) linked from:

- `perfect-steak-date-night-guide` (EN + FR): inline "cutting board" anchor at the resting step
- `cooking-essentials-starter-kit` (EN + FR): added sentence after OXO cutting board recommendation
- `wok-hei-at-home` (EN + FR): added "cutting board" anchor in the mise en place prep paragraph

### Audit result
`validate:source` passes cleanly. No frontmatter, schema, or metadata issues found across 18 recipes, 15 articles, and 2 reviews.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EowPkwvC7wYgspKzHvB3ui)_