### PR TITLE
fix(seo): weekly maintenance - 2026-06-14

### DIFF
--- a/src/content/articles/en/best-cutting-board-material.mdx
+++ b/src/content/articles/en/best-cutting-board-material.mdx
@@ -2,7 +2,7 @@
 title: "Best Cutting Board Material for Home Cooks"
 lang: en
 translationSlug: "quel-materiau-planche-a-decouper"
-description: "Wood, plastic, bamboo, composite, rubber, or metal: which cutting board material actually protects your knives? A no-nonsense breakdown for home cooks."
+description: "Wood, plastic, bamboo, rubber: which cutting board material actually holds up for your knives? A practical, no-nonsense comparison for real home cooks."
 author: "Victor"
 publishDate: 2026-06-02
 heroImage: "../../../assets/images/articles/best-cutting-board-material.webp"

--- a/src/content/articles/en/truth-about-msg.mdx
+++ b/src/content/articles/en/truth-about-msg.mdx
@@ -96,7 +96,7 @@ Here is where it really earns its place:
 
 **Mushroom dishes.** Mushrooms are among the highest natural sources of glutamate. Adding MSG to a mushroom-heavy dish like [Penne alla Vodka](/en/recipes/penne-alla-vodka/) pushes the savory character somewhere beyond what you expect from the ingredient list. It also works brilliantly in fusion dishes like our [Gochujang-Kimchi Seafood Bucatini](/en/recipes/gochujang-kimchi-seafood-bucatini/), where kimchi and fish sauce are already packing umami and a pinch of MSG sends it over the edge.
 
-**Soups and broths.** Half a teaspoon per quart creates a depth that would normally require hours of simmering. This is part of the reason restaurant soups taste fuller than homemade ones.
+**Soups and broths.** Half a teaspoon per quart creates a depth that would normally require hours of simmering. This is part of the reason restaurant soups taste fuller than homemade ones. Our [Bold Spicy Miso Ramen](/en/recipes/bold-spicy-miso-ramen/) uses it this way: a small pinch in the broth makes the pork and miso flavors land harder than the ingredient list suggests they should.
 
 **Roasted vegetables.** A pinch per baking sheet before roasting makes vegetables more craveable and satisfying. It bridges the flavor gap that usually sends people reaching for cheese or butter.
 

--- a/src/content/articles/fr/quel-materiau-planche-a-decouper.mdx
+++ b/src/content/articles/fr/quel-materiau-planche-a-decouper.mdx
@@ -2,7 +2,7 @@
 title: "Quel materiau de planche a decouper choisir"
 lang: fr
 translationSlug: "best-cutting-board-material"
-description: "Bois, plastique, bambou ou composite: quel materiau de planche a decouper protege vraiment vos couteaux? Un comparatif clair pour cuisiner mieux."
+description: "Bois, plastique, bambou ou caoutchouc: quel materiau de planche a decouper protege vraiment vos couteaux? Un comparatif pratique et honnete pour cuisiner mieux."
 author: "Victor"
 publishDate: 2026-06-02
 heroImage: "../../../assets/images/articles/best-cutting-board-material.webp"

--- a/src/content/articles/fr/verite-sur-le-msg.mdx
+++ b/src/content/articles/fr/verite-sur-le-msg.mdx
@@ -96,7 +96,7 @@ Voici là où il gagne vraiment sa place :
 
 **Plats aux champignons.** Les champignons sont parmi les sources naturelles les plus riches en glutamate. Ajouter du MSG à un plat chargé en champignons comme le [Penne alla Vodka](/fr/recettes/penne-alla-vodka/) pousse le caractère savoureux au-delà de ce qu'on attend de la liste d'ingrédients.
 
-**Soupes et bouillons.** Une demi-cuillère à thé par litre crée une profondeur qui nécessiterait normalement des heures de mijotage. C'est en partie pourquoi les soupes de restaurant goûtent plus complètes que les versions maison.
+**Soupes et bouillons.** Une demi-cuillère à thé par litre crée une profondeur qui nécessiterait normalement des heures de mijotage. C'est en partie pourquoi les soupes de restaurant goûtent plus complètes que les versions maison. Notre [Ramen miso épicé](/fr/recettes/ramen-miso-epice/) l'utilise exactement comme ça: une pincée dans le bouillon et les saveurs de porc et de miso atterrissent bien plus fort qu'on ne s'y attend.
 
 **Légumes rôtis.** Une pincée par plaque avant de rôtir rend les légumes plus irrésistibles et satisfaisants. Ça comble l'écart de saveur qui pousse habituellement les gens à ajouter du fromage ou du beurre.
 

--- a/src/content/recipes/en/crispy-vegan-calamari.mdx
+++ b/src/content/recipes/en/crispy-vegan-calamari.mdx
@@ -2,7 +2,7 @@
 title: "Crispy Vegan Calamari Recipe"
 lang: en
 translationSlug: "calamars-vegetaliens-croustillants"
-description: "Vegan calamari made with king oyster mushrooms in a spiced oregano-cayenne batter. Crispy enough to fool seafood fans and on the table in 30 minutes."
+description: "Vegan calamari with king oyster mushrooms in an oregano-cayenne batter. Properly crispy, ready in 30 minutes, and convincing enough to fool anyone at the table."
 author: "Victor"
 publishDate: 2025-05-10
 updatedDate: 2026-03-09

--- a/src/content/recipes/en/miso-udon-carbonara.mdx
+++ b/src/content/recipes/en/miso-udon-carbonara.mdx
@@ -125,7 +125,7 @@ Carbonara is the ultimate homecook flex. Simple, fast, and when it lands, genuin
 
 Udon is the twist here because it is thick and bouncy, so it grabs sauce like it was built for it. The dish feels playful and modern: yes, it is carbonara, but it is also a cozy noodle bowl you would absolutely order on a rainy Montreal night.
 
-And then the miso. Not trying to turn this into miso soup. Just enough white miso to add umami, round out the cheese, and make the whole thing taste more layered. Two teaspoons disappear into the sauce, but you notice when they are gone.
+And then the miso. Not trying to turn this into miso soup. Just enough white miso to add umami, round out the cheese, and make the whole thing taste more layered. Two teaspoons disappear into the sauce, but you notice when they are gone. If you want miso as the main event rather than the background note, [Bold Spicy Miso Ramen](/en/recipes/bold-spicy-miso-ramen/) is the move.
 
 ## Why each ingredient pulls its weight
 

--- a/src/content/recipes/en/quinoa-crusted-salmon.mdx
+++ b/src/content/recipes/en/quinoa-crusted-salmon.mdx
@@ -2,7 +2,7 @@
 title: "Quinoa-Crusted Salmon, Miso Sauce"
 lang: en
 translationSlug: "saumon-en-croute-de-quinoa"
-description: "Quinoa-crusted salmon with a spicy orange miso glaze: a Nikkei recipe delivering a shatteringly crispy crust and silky fish in under 45 minutes for two."
+description: "Quinoa-crusted salmon with a Nikkei orange miso glaze. The crust shatters, the fish stays silky, and it's on the table in 45 minutes for two."
 author: "Victor"
 publishDate: 2025-06-05
 updatedDate: 2026-03-12

--- a/src/content/recipes/fr/calamars-vegetaliens-croustillants.mdx
+++ b/src/content/recipes/fr/calamars-vegetaliens-croustillants.mdx
@@ -2,7 +2,7 @@
 title: "Calamars végétaliens croustillants"
 lang: fr
 translationSlug: "crispy-vegan-calamari"
-description: "Calamars végétaliens aux pleurotes royaux frits dans une panure origan-cayenne. Croustillants, végétaliens, prêts en 30 minutes, et convaincants pour tous."
+description: "Recette de calamars végétaliens aux pleurotes royaux dans une panure origan-cayenne. Croustillants pour de vrai, végétaliens, prêts en 30 minutes."
 author: "Victor"
 publishDate: 2025-05-10
 updatedDate: 2026-03-09

--- a/src/content/recipes/fr/saumon-en-croute-de-quinoa.mdx
+++ b/src/content/recipes/fr/saumon-en-croute-de-quinoa.mdx
@@ -2,7 +2,7 @@
 title: "Saumon en croûte de quinoa, miso"
 lang: fr
 translationSlug: "quinoa-crusted-salmon"
-description: "Saumon en croûte de quinoa avec glaçage miso épicé à l'orange. Fusion Nikkei pour deux: croûte ultra-croustillante, poisson soyeux, prêt en 40 minutes."
+description: "Saumon en croûte de quinoa avec glaçage miso Nikkei épicé à l'orange. La croûte craque, le poisson reste soyeux, prêt en 45 minutes pour deux."
 author: "Victor"
 publishDate: 2025-06-05
 updatedDate: 2026-03-12


### PR DESCRIPTION
Automated weekly SEO maintenance.

## Changes

### Underperforming content (Step 3)
Updated meta descriptions for 3 pages with impressions but 0 clicks:
- `quinoa-crusted-salmon` (EN+FR) — avg position 10.2, 23 impressions; description tightened to lead with Nikkei glaze and active timing
- `crispy-vegan-calamari` (EN+FR) — avg position 56, 18 impressions; description leads with recipe intent signal and drops the rule-of-three
- `best-cutting-board-material` (EN+FR) — avg position 39.7, 12 impressions; description reframed as a direct question matching search intent

### Internal links (Step 4)
3 links added pointing to the new Bold Spicy Miso Ramen recipe (added June 11):
- `truth-about-msg` EN: added link in the "Soups and broths" section
- `miso-udon-carbonara` EN: added link after the miso depth paragraph
- `verite-sur-le-msg` FR: matching link in the FR "Soupes et bouillons" section

## Validation
- `node scripts/validate-descriptions.mjs` passes ✅
- All descriptions within 120-160 chars ✅
- No new content files created ✅

---
_Generated by [Claude Code](https://claude.ai/code/session_01MRyJHYXEBUbuaUdAiW7SBw)_