### PR TITLE
feat(home): feature reviews ahead of recipes + clarify date score

### DIFF
--- a/src/components/ReviewQuickFacts.astro
+++ b/src/components/ReviewQuickFacts.astro
@@ -61,6 +61,7 @@ const googleMapsUrl = `https://www.google.com/maps/search/?api=1&query=${encodeU
       <div class="text-xs text-warm-500 dark:text-warm-400">/ 10</div>
     </div>
   </div>
+  <p class="mb-4 text-xs italic text-warm-500 dark:text-warm-400">{t(locale, "review.dateScoreNote")}</p>
 
   <dl class="space-y-3 text-sm">
     <div>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -155,6 +155,7 @@
   },
   "review": {
     "dateScore": "Date Score",
+    "dateScoreNote": "Scored on date-night vibes, not the food.",
     "priceRange": "Price Range",
     "cuisine": "Cuisine",
     "neighborhood": "Neighborhood",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -155,6 +155,7 @@
   },
   "review": {
     "dateScore": "Score rendez-vous",
+    "dateScoreNote": "Note pour l'ambiance d'un rendez-vous, pas la bouffe.",
     "priceRange": "Gamme de prix",
     "cuisine": "Cuisine",
     "neighborhood": "Quartier",

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -1,8 +1,9 @@
 ---
 import BaseLayout from "@layouts/BaseLayout.astro";
 import RecipeCard from "@components/RecipeCard.astro";
+import ReviewCard from "@components/ReviewCard.astro";
 import { Picture } from "astro:assets";
-import { t, getRecipeLocalizedPath, getArticleLocalizedPath, getReviewLocalizedPath } from "@i18n/utils";
+import { t, getRecipeLocalizedPath, getArticleLocalizedPath } from "@i18n/utils";
 import { difficultyBadge } from "@utils/recipe";
 import { SITE_URL } from "@utils/constants";
 import { formatDuration } from "@utils/format";
@@ -31,7 +32,7 @@ const allReviews = await getCollection("reviews");
 const recentReviews = allReviews
   .filter((r) => r.data.lang === "en")
   .sort((a, b) => b.data.publishDate.getTime() - a.data.publishDate.getTime())
-  .slice(0, 2);
+  .slice(0, 3);
 
 const FAVORITE_SLUGS = ["crispy-vegan-calamari", "lemon-posset-brulee", "quinoa-crusted-salmon"];
 const favoriteRecipes = FAVORITE_SLUGS.map((slug) =>
@@ -114,9 +115,51 @@ const favoriteRecipes = FAVORITE_SLUGS.map((slug) =>
     </div>
   </section>
 
+  <!-- Where to Take Your Date -->
+  {recentReviews.length > 0 && (
+    <section class="bg-white px-4 py-section dark:bg-warm-950" aria-labelledby="latest-reviews">
+      <div class="mx-auto max-w-content">
+        <div class="mb-10 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <h2 id="latest-reviews" class="font-heading text-heading-1 font-normal text-warm-900 dark:text-warm-100">
+              {t(locale, "home.latestReviews")}
+            </h2>
+          </div>
+          <a
+            href={`/${locale}/reviews/`}
+            class="font-ui text-sm font-bold uppercase tracking-widest text-warm-800 underline decoration-brand-wine decoration-2 underline-offset-8 hover:text-brand-wine dark:text-warm-200 dark:decoration-brand-wine-dark dark:hover:text-brand-wine-dark"
+          >
+            {t(locale, "home.viewAllReviews")}
+          </a>
+        </div>
+        <div class="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
+          {recentReviews.map((review) => {
+            const slug = review.id.replace(/^en\//, "");
+            return (
+              <ReviewCard
+                title={review.data.title}
+                description={review.data.description}
+                slug={slug}
+                locale={locale}
+                heroImage={review.data.heroImage as ImageMetadata}
+                heroImageAlt={review.data.heroImageAlt}
+                restaurantName={review.data.restaurantName}
+                neighborhood={review.data.neighborhood}
+                cuisine={review.data.cuisine}
+                priceRange={review.data.priceRange}
+                dateScore={review.data.dateScore}
+                headingLevel="h3"
+              />
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  )}
+
   <!-- Fresh from the Kitchen -->
   {recentRecipes.length >= 3 && (
-    <section class="bg-white px-4 py-section dark:bg-warm-950" aria-labelledby="fresh-kitchen">
+    <section class="bg-warm-50 px-4 py-section dark:bg-warm-950" aria-labelledby="fresh-kitchen">
       <div class="mx-auto max-w-content">
         <h2 id="fresh-kitchen" class="mb-8 font-heading text-3xl font-normal text-warm-800 dark:text-warm-100">
           {t(locale, "home.freshFromKitchen")}
@@ -205,7 +248,7 @@ const favoriteRecipes = FAVORITE_SLUGS.map((slug) =>
 
   <!-- Our Favorites -->
   {favoriteRecipes.length >= 3 && (
-    <section class="bg-warm-50 px-4 py-section dark:bg-warm-950" aria-labelledby="our-favorites">
+    <section class="bg-white px-4 py-section dark:bg-warm-950" aria-labelledby="our-favorites">
       <div class="mx-auto max-w-content">
         <div class="mb-10 text-center">
           <h2 id="our-favorites" class="font-heading text-heading-1 font-normal text-warm-900 dark:text-warm-100">
@@ -243,7 +286,7 @@ const favoriteRecipes = FAVORITE_SLUGS.map((slug) =>
 
   <!-- Culinary Narratives -->
   {recentArticles.length >= 3 && (
-    <section class="bg-white px-4 py-section dark:bg-warm-950" aria-labelledby="culinary-narratives">
+    <section class="bg-warm-50 px-4 py-section dark:bg-warm-950" aria-labelledby="culinary-narratives">
       <div class="mx-auto max-w-content">
         {/* Header */}
         <div class="mb-10 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
@@ -335,61 +378,6 @@ const favoriteRecipes = FAVORITE_SLUGS.map((slug) =>
               );
             })}
           </div>
-        </div>
-      </div>
-    </section>
-  )}
-
-  <!-- Where to Take Your Date -->
-  {recentReviews.length > 0 && (
-    <section class="bg-warm-50 px-4 py-section dark:bg-warm-950" aria-labelledby="latest-reviews">
-      <div class="mx-auto max-w-content">
-        <div class="mb-10 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
-          <div>
-            <h2 id="latest-reviews" class="font-heading text-heading-1 font-normal text-warm-900 dark:text-warm-100">
-              {t(locale, "home.latestReviews")}
-            </h2>
-          </div>
-          <a
-            href={`/${locale}/reviews/`}
-            class="font-ui text-sm font-bold uppercase tracking-widest text-warm-800 underline decoration-brand-wine decoration-2 underline-offset-8 hover:text-brand-wine dark:text-warm-200 dark:decoration-brand-wine-dark dark:hover:text-brand-wine-dark"
-          >
-            {t(locale, "home.viewAllReviews")}
-          </a>
-        </div>
-        <div class="grid grid-cols-1 gap-8 sm:grid-cols-2">
-          {recentReviews.map((review) => {
-            const slug = review.id.replace(/^en\//, "");
-            return (
-              <a href={getReviewLocalizedPath(locale, slug)} class="group flex flex-col gap-4 sm:flex-row">
-                <div class="relative shrink-0 overflow-hidden rounded-xl border border-warm-200 dark:border-warm-700 sm:w-48">
-                  <Picture
-                    src={review.data.heroImage as ImageMetadata}
-                    alt={review.data.heroImageAlt}
-                    widths={[200, 400]}
-                    sizes="(max-width: 640px) 100vw, 192px"
-                    formats={["avif", "webp"]} fallbackFormat="webp"
-                    class="aspect-[4/3] h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
-                    loading="lazy"
-                  />
-                  <div class="absolute right-2 top-2 flex h-8 w-8 items-center justify-center rounded-lg bg-brand-wine text-sm font-bold text-white shadow dark:bg-brand-wine-dark">
-                    {review.data.dateScore}
-                  </div>
-                </div>
-                <div class="flex flex-col justify-center">
-                  <span class="font-ui text-xs font-bold uppercase tracking-wider text-brand-wine dark:text-brand-wine-dark">
-                    {review.data.neighborhood} · {review.data.priceRange}
-                  </span>
-                  <h3 class="mt-1 font-heading text-lg font-normal text-warm-800 dark:text-warm-100">
-                    {review.data.restaurantName}
-                  </h3>
-                  <p class="mt-1 text-sm text-warm-500 dark:text-warm-400">
-                    {review.data.description}
-                  </p>
-                </div>
-              </a>
-            );
-          })}
         </div>
       </div>
     </section>

--- a/src/pages/fr/index.astro
+++ b/src/pages/fr/index.astro
@@ -1,8 +1,9 @@
 ---
 import BaseLayout from "@layouts/BaseLayout.astro";
 import RecipeCard from "@components/RecipeCard.astro";
+import ReviewCard from "@components/ReviewCard.astro";
 import { Picture } from "astro:assets";
-import { t, getRecipeLocalizedPath, getArticleLocalizedPath, getReviewLocalizedPath } from "@i18n/utils";
+import { t, getRecipeLocalizedPath, getArticleLocalizedPath } from "@i18n/utils";
 import { difficultyBadge } from "@utils/recipe";
 import { SITE_URL } from "@utils/constants";
 import { formatDuration } from "@utils/format";
@@ -31,7 +32,7 @@ const allReviews = await getCollection("reviews");
 const recentReviews = allReviews
   .filter((r) => r.data.lang === "fr")
   .sort((a, b) => b.data.publishDate.getTime() - a.data.publishDate.getTime())
-  .slice(0, 2);
+  .slice(0, 3);
 
 const FAVORITE_SLUGS = ["calamars-vegetaliens-croustillants", "posset-brulee-au-citron", "saumon-en-croute-de-quinoa"];
 const favoriteRecipes = FAVORITE_SLUGS.map((slug) =>
@@ -114,9 +115,51 @@ const favoriteRecipes = FAVORITE_SLUGS.map((slug) =>
     </div>
   </section>
 
+  <!-- Where to Take Your Date -->
+  {recentReviews.length > 0 && (
+    <section class="bg-white px-4 py-section dark:bg-warm-950" aria-labelledby="latest-reviews">
+      <div class="mx-auto max-w-content">
+        <div class="mb-10 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <h2 id="latest-reviews" class="font-heading text-heading-1 font-normal text-warm-900 dark:text-warm-100">
+              {t(locale, "home.latestReviews")}
+            </h2>
+          </div>
+          <a
+            href={`/${locale}/critiques/`}
+            class="font-ui text-sm font-bold uppercase tracking-widest text-warm-800 underline decoration-brand-wine decoration-2 underline-offset-8 hover:text-brand-wine dark:text-warm-200 dark:decoration-brand-wine-dark dark:hover:text-brand-wine-dark"
+          >
+            {t(locale, "home.viewAllReviews")}
+          </a>
+        </div>
+        <div class="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
+          {recentReviews.map((review) => {
+            const slug = review.id.replace(/^fr\//, "");
+            return (
+              <ReviewCard
+                title={review.data.title}
+                description={review.data.description}
+                slug={slug}
+                locale={locale}
+                heroImage={review.data.heroImage as ImageMetadata}
+                heroImageAlt={review.data.heroImageAlt}
+                restaurantName={review.data.restaurantName}
+                neighborhood={review.data.neighborhood}
+                cuisine={review.data.cuisine}
+                priceRange={review.data.priceRange}
+                dateScore={review.data.dateScore}
+                headingLevel="h3"
+              />
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  )}
+
   <!-- Fresh from the Kitchen -->
   {recentRecipes.length >= 3 && (
-    <section class="bg-white px-4 py-section dark:bg-warm-950" aria-labelledby="fresh-kitchen">
+    <section class="bg-warm-50 px-4 py-section dark:bg-warm-950" aria-labelledby="fresh-kitchen">
       <div class="mx-auto max-w-content">
         <h2 id="fresh-kitchen" class="mb-8 font-heading text-3xl font-normal text-warm-800 dark:text-warm-100">
           {t(locale, "home.freshFromKitchen")}
@@ -205,7 +248,7 @@ const favoriteRecipes = FAVORITE_SLUGS.map((slug) =>
 
   <!-- Our Favorites -->
   {favoriteRecipes.length >= 3 && (
-    <section class="bg-warm-50 px-4 py-section dark:bg-warm-950" aria-labelledby="our-favorites">
+    <section class="bg-white px-4 py-section dark:bg-warm-950" aria-labelledby="our-favorites">
       <div class="mx-auto max-w-content">
         <div class="mb-10 text-center">
           <h2 id="our-favorites" class="font-heading text-heading-1 font-normal text-warm-900 dark:text-warm-100">
@@ -243,7 +286,7 @@ const favoriteRecipes = FAVORITE_SLUGS.map((slug) =>
 
   <!-- Culinary Narratives -->
   {recentArticles.length >= 3 && (
-    <section class="bg-white px-4 py-section dark:bg-warm-950" aria-labelledby="culinary-narratives">
+    <section class="bg-warm-50 px-4 py-section dark:bg-warm-950" aria-labelledby="culinary-narratives">
       <div class="mx-auto max-w-content">
         {/* Header */}
         <div class="mb-10 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
@@ -335,61 +378,6 @@ const favoriteRecipes = FAVORITE_SLUGS.map((slug) =>
               );
             })}
           </div>
-        </div>
-      </div>
-    </section>
-  )}
-
-  <!-- Where to Take Your Date -->
-  {recentReviews.length > 0 && (
-    <section class="bg-warm-50 px-4 py-section dark:bg-warm-950" aria-labelledby="latest-reviews">
-      <div class="mx-auto max-w-content">
-        <div class="mb-10 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
-          <div>
-            <h2 id="latest-reviews" class="font-heading text-heading-1 font-normal text-warm-900 dark:text-warm-100">
-              {t(locale, "home.latestReviews")}
-            </h2>
-          </div>
-          <a
-            href={`/${locale}/critiques/`}
-            class="font-ui text-sm font-bold uppercase tracking-widest text-warm-800 underline decoration-brand-wine decoration-2 underline-offset-8 hover:text-brand-wine dark:text-warm-200 dark:decoration-brand-wine-dark dark:hover:text-brand-wine-dark"
-          >
-            {t(locale, "home.viewAllReviews")}
-          </a>
-        </div>
-        <div class="grid grid-cols-1 gap-8 sm:grid-cols-2">
-          {recentReviews.map((review) => {
-            const slug = review.id.replace(/^fr\//, "");
-            return (
-              <a href={getReviewLocalizedPath(locale, slug)} class="group flex flex-col gap-4 sm:flex-row">
-                <div class="relative shrink-0 overflow-hidden rounded-xl border border-warm-200 dark:border-warm-700 sm:w-48">
-                  <Picture
-                    src={review.data.heroImage as ImageMetadata}
-                    alt={review.data.heroImageAlt}
-                    widths={[200, 400]}
-                    sizes="(max-width: 640px) 100vw, 192px"
-                    formats={["avif", "webp"]} fallbackFormat="webp"
-                    class="aspect-[4/3] h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
-                    loading="lazy"
-                  />
-                  <div class="absolute right-2 top-2 flex h-8 w-8 items-center justify-center rounded-lg bg-brand-wine text-sm font-bold text-white shadow dark:bg-brand-wine-dark">
-                    {review.data.dateScore}
-                  </div>
-                </div>
-                <div class="flex flex-col justify-center">
-                  <span class="font-ui text-xs font-bold uppercase tracking-wider text-brand-wine dark:text-brand-wine-dark">
-                    {review.data.neighborhood} · {review.data.priceRange}
-                  </span>
-                  <h3 class="mt-1 font-heading text-lg font-normal text-warm-800 dark:text-warm-100">
-                    {review.data.restaurantName}
-                  </h3>
-                  <p class="mt-1 text-sm text-warm-500 dark:text-warm-400">
-                    {review.data.description}
-                  </p>
-                </div>
-              </a>
-            );
-          })}
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Why
Shifting emphasis toward restaurant reviews "for now" as more review content is published, and making it clear the Date Score rates dating vibes, not food quality.

## Part 1 — Reviews featured ahead of recipes
- New homepage order (EN + FR): **Hero → Where to Take Your Date → Fresh from the Kitchen → Our Favorites → Culinary Narratives**.
- Reviews section now shows **3 cards** (was 2) in a 3-column grid, rendered via the existing `ReviewCard` component for clean layout. Title + "View All Reviews" link preserved.
- Rebalanced alternating section background shades so no two same-color blocks touch.
- Hero, nav, and recipe SEO untouched — this is a reversible emphasis change, not a brand pivot.

## Part 2 — Clarify the Date Score
- Added a clarifier line under "Date Score / 10" in the review Quick Facts sidebar:
  - EN: *Scored on date-night vibes, not the food.*
  - FR: *Note pour l'ambiance d'un rendez-vous, pas la bouffe.*
- Name "Date Score" kept; card badges and JSON-LD intentionally unchanged.

## Verification
- `validate:source` passes (Picture fallbacks, tag translations, EN/FR parity, title/description SEO). New `dateScoreNote` key present in both locales.
- `npm run check`: only the 3 pre-existing errors remain (present on `main`, in untouched files).
- Local `npm run build` hits an environmental `MissingSharp` error (Node 25 + Sharp) unrelated to this change; builds normally in CI/Cloudflare.

🤖 Generated with [Claude Code](https://claude.com/claude-code)