### PR TITLE
fix(review): correct FR wok-hei article link in Oncle Lee Kăo review

### DIFF
--- a/src/content/reviews/fr/oncle-lee-kao-montreal.mdx
+++ b/src/content/reviews/fr/oncle-lee-kao-montreal.mdx
@@ -259,4 +259,4 @@ Double date ou soirée de groupe? C'est là que ça clique vraiment. Cinq sur ci
 
 Oncle Lee Kăo récolte **7,8 sur 10**. La cuisine est solide, la salle justifie le Bib Gourmand, et le prix tient la route pour ce qu'on reçoit. Si tu manges déjà souvent dans des restaurants chinois, certains profils de saveurs te sembleront familiers à un prix premium, et ça ne comblera pas le craving classique de bouffe réconfortante. Mais quand tu veux une salle qui crée une ambiance, des assiettes à partager pour une soirée qui s'étire, et de la bouffe qui tient sur la longueur, ça mérite sa place dans la rotation montréalaise.
 
-Si tu veux ramener un peu de cette énergie de grill à la maison entre deux soupers au resto, notre guide sur le [wok hei à la maison](/fr/articles/wok-hei-at-home/) vaut la lecture avant ta prochaine soirée sauté en amoureux.
+Si tu veux ramener un peu de cette énergie de grill à la maison entre deux soupers au resto, notre guide sur le [wok hei à la maison](/fr/articles/wok-hei-a-la-maison/) vaut la lecture avant ta prochaine soirée sauté en amoureux.


### PR DESCRIPTION
## Summary

- Fixes a broken internal link in `src/content/reviews/fr/oncle-lee-kao-montreal.mdx`
- The FR cross-link used the EN slug `/fr/articles/wok-hei-at-home/` instead of the correct FR slug `/fr/articles/wok-hei-a-la-maison/`
- This caused `validate-build` to fail with `[link-redirect]`, blocking the Cloudflare Pages deploy after PR #278 merged

## Test plan

- [x] `npm run build` passes locally (validate-source + validate-build both green)
- [ ] Cloudflare Pages deploys successfully and `/fr/critiques/oncle-lee-kao-montreal/` is live

---
_Generated by [Claude Code](https://claude.ai/code/session_016qt3ftDkYzBKwcJ4Najojb)_