### PR TITLE
fix(seo): weekly maintenance - 2026-07-12

### DIFF
--- a/src/content/articles/en/anova-vs-joule-sous-vide-comparison.mdx
+++ b/src/content/articles/en/anova-vs-joule-sous-vide-comparison.mdx
@@ -2,7 +2,7 @@
 title: "Anova vs Joule: Sous Vide Buyer's Guide"
 lang: "en"
 translationSlug: "anova-vs-joule-comparatif-sous-vide"
-description: "Choosing your first sous vide circulator? This honest breakdown of Anova vs Joule tells you exactly which one fits your kitchen, your habits, and your budget."
+description: "Anova vs Joule: side-by-side specs and honest kitchen results from someone who's cooked with both. Here's which one to buy in 2026."
 author: "Victor"
 publishDate: 2026-05-26
 heroImage: "../../../assets/images/articles/anova-vs-joule-sous-vide-comparison.webp"

--- a/src/content/articles/fr/anova-vs-joule-comparatif-sous-vide.mdx
+++ b/src/content/articles/fr/anova-vs-joule-comparatif-sous-vide.mdx
@@ -2,7 +2,7 @@
 title: "Anova vs Joule : guide d'achat sous vide"
 lang: "fr"
 translationSlug: "anova-vs-joule-sous-vide-comparison"
-description: "Anova ou Joule pour votre premier sous vide? Ce comparatif honnête vous dit exactement lequel convient à votre cuisine, vos habitudes et votre budget."
+description: "Anova vs Joule: specs comparées et tests en cuisine honnêtes. Voici lequel acheter en 2026 et pourquoi l'autre ne convient pas à tout le monde."
 author: "Victor"
 publishDate: 2026-05-26
 heroImage: "../../../assets/images/articles/anova-vs-joule-sous-vide-comparison.webp"

--- a/src/content/recipes/en/quinoa-crusted-salmon.mdx
+++ b/src/content/recipes/en/quinoa-crusted-salmon.mdx
@@ -2,7 +2,7 @@
 title: "Quinoa-Crusted Salmon, Miso Sauce"
 lang: en
 translationSlug: "saumon-en-croute-de-quinoa"
-description: "Quinoa-crusted salmon with a Nikkei orange miso glaze. The crust shatters, the fish stays silky, and it's on the table in 45 minutes for two."
+description: "Quinoa-crusted salmon with a Nikkei orange miso glaze. The crust shatters, the fish stays silky, and dinner for two is ready in 40 minutes."
 author: "Victor"
 publishDate: 2025-06-05
 updatedDate: 2026-03-12

--- a/src/content/recipes/fr/saumon-en-croute-de-quinoa.mdx
+++ b/src/content/recipes/fr/saumon-en-croute-de-quinoa.mdx
@@ -2,7 +2,7 @@
 title: "Saumon en croûte de quinoa, miso"
 lang: fr
 translationSlug: "quinoa-crusted-salmon"
-description: "Saumon en croûte de quinoa avec glaçage miso Nikkei épicé à l'orange. La croûte craque, le poisson reste soyeux, prêt en 45 minutes pour deux."
+description: "Saumon en croûte de quinoa avec glaçage miso Nikkei à l'orange. La croûte craque, le poisson reste soyeux, et c'est prêt en 40 minutes pour deux."
 author: "Victor"
 publishDate: 2025-06-05
 updatedDate: 2026-03-12

--- a/src/content/reviews/en/mckiernan-montreal.mdx
+++ b/src/content/reviews/en/mckiernan-montreal.mdx
@@ -2,7 +2,7 @@
 title: "McKiernan: Canal Lachine Brunch Review"
 lang: en
 translationSlug: mckiernan-montreal
-description: "McKiernan delivers rotisserie comfort and lively brunch energy by the Lachine Canal. Spacious room, great coffee, and generous shareable plates."
+description: "Bomba schnitzel, devilled brussels sprouts, honey garlic ribs: McKiernan does Canal Lachine brunch better than almost anywhere in Montreal."
 author: "Victor"
 publishDate: 2026-03-23
 updatedDate: 2026-07-10

--- a/src/content/reviews/fr/mckiernan-montreal.mdx
+++ b/src/content/reviews/fr/mckiernan-montreal.mdx
@@ -2,7 +2,7 @@
 title: "McKiernan : brunch Canal Lachine"
 lang: fr
 translationSlug: mckiernan-montreal
-description: "McKiernan offre du comfort food rotisserie et une energie brunch contagieuse pres du Canal Lachine. Grande salle, excellent cafe et assiettes genereuses."
+description: "Schnitzel bomba, choux de Bruxelles à la diable et côtes levées: McKiernan fait le meilleur brunch en amoureux au Canal Lachine à Montréal."
 author: "Victor"
 publishDate: 2026-03-23
 updatedDate: 2026-07-10


### PR DESCRIPTION
## Summary

Automated weekly SEO maintenance run for 2026-07-12.

### Audit findings
- `validate-descriptions.mjs` passed on all 19 recipes, 15 articles, 5 reviews
- All recipe bodies exceed 800 words with 5+ H2 headings and internal links
- All article bodies exceed 800 words with 3+ H2 headings and internal links
- No hreflang, sitemap, or tag-parity issues found (source-level checks)

### Description optimizations (Step 3)

Top 3 underperformers from the 2026-07-06 ranking snapshot (high impressions, 0 clicks, not touched by last week's maintenance):

- **mckiernan-montreal** (31 impressions, 0 clicks): Previous description buried the "bomba schnitzel" keyword that drives 16 of 31 impressions at position 8.9. New description leads with the dish to hook those searchers. EN + FR updated.
- **quinoa-crusted-salmon** (11 impressions, 0 clicks): Tightened phrasing and corrected timing (40 min, not 45). Ranks at position 7.8 for "quinoa crusted fish". EN + FR updated.
- **anova-vs-joule-sous-vide-comparison** (6 impressions, position 4, 0 clicks): Ranking at position 4 should yield clicks; description was too generic. Replaced with specific, action-oriented copy. EN + FR updated.

### Step 4 (internal links)
Skipped. No new recipe or article content was published in the past 7 days.

### Image issues (flagged, not fixed here)
These require `/optimize-image` and are out of scope for this text-only maintenance run:
- 9 recipe hero images still in JPG format (not WebP): `3-day-aged-miso-duck-breast`, `beef-ragu-pappardelle`, `bold-spicy-miso-ramen`, `chocolate-tofu-pudding`, `lamb-meatballs-gochujang-glaze`, `miso-udon-carbonara`, `pate-a-choux`, `penne-alla-vodka`, `quinoa-crusted-salmon`
- `penne-alla-vodka` hero at 204 KB, `cauliflower-steak-with-romesco-sauce` at 200 KB (largest source images)
- `pork-osso-buco` has only 1 step image; `gochujang-kimchi-seafood-bucatini` has only 2

### Content gaps to queue in Notion
None identified this week.

🤖 Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01SsNMRSmMifqofhBHr5cqin)_