### PR TITLE
fix(seo): weekly maintenance 2026-07-19

### DIFF
--- a/src/content/articles/en/best-cutting-board-material.mdx
+++ b/src/content/articles/en/best-cutting-board-material.mdx
@@ -2,7 +2,7 @@
 title: "Best Cutting Board Material for Home Cooks"
 lang: en
 translationSlug: "quel-materiau-planche-a-decouper"
-description: "Wood protects knives, HDPE handles raw meat, bamboo saves money. Here's how every cutting board material actually stacks up."
+description: "Wood, HDPE, Katori, Hasegawa: we compared every cutting board material by knife protection, hygiene, and durability. Here's what actually holds up."
 author: "Victor"
 publishDate: 2026-06-02
 heroImage: "../../../assets/images/articles/best-cutting-board-material.webp"

--- a/src/content/articles/fr/quel-materiau-planche-a-decouper.mdx
+++ b/src/content/articles/fr/quel-materiau-planche-a-decouper.mdx
@@ -2,7 +2,7 @@
 title: "Quel materiau de planche a decouper choisir"
 lang: fr
 translationSlug: "best-cutting-board-material"
-description: "Le bois protège vos couteaux, le PEHD convient pour la viande crue, le bambou pour les petits budgets. Comparatif complet par sécurité, hygiène et durabilité."
+description: "Bois, PEHD, bambou, Katori ou Hasegawa : on compare chaque matériau de planche à découper selon la protection des couteaux, l'hygiène et la solidité."
 author: "Victor"
 publishDate: 2026-06-02
 heroImage: "../../../assets/images/articles/best-cutting-board-material.webp"

--- a/src/content/reviews/en/oncle-lee-kao-montreal.mdx
+++ b/src/content/reviews/en/oncle-lee-kao-montreal.mdx
@@ -2,7 +2,7 @@
 title: "Oncle Lee Kăo: Chinese Grill Energy, Montréal"
 lang: en
 translationSlug: oncle-lee-kao-montreal
-description: "Oncle Lee Kăo, Michelin Bib Gourmand in Old Montréal: contemporary Chinese grill, shareable plates, a soaring room, and evenings built for lingering."
+description: "Oncle Lee Kăo review: Michelin Bib Gourmand Chinese grill in Old Montreal. Smoky plates built for sharing, a gorgeous room, and real date-night energy."
 author: "Victor"
 publishDate: 2026-07-02
 heroImage: "../../../assets/images/reviews/oncle-lee-kao-montreal.jpg"

--- a/src/content/reviews/en/othym-montreal.mdx
+++ b/src/content/reviews/en/othym-montreal.mdx
@@ -2,7 +2,7 @@
 title: "Othym: Montréal's BYOB Seasonal Standout"
 lang: en
 translationSlug: othym-montreal
-description: "Othym brings Michelin-recommended seasonal cooking to Montreal's Village. Relaxed BYOB setting, ingredient-driven plates, and honest value for a date night."
+description: "O-Thym review: Michelin-recommended BYOB in Montreal's Village. Seasonal Quebec cooking, honest prices, and a calm room that actually works for a date."
 author: "Victor"
 publishDate: 2026-06-25
 heroImage: "../../../assets/images/reviews/othym-montreal.jpg"

--- a/src/content/reviews/fr/oncle-lee-kao-montreal.mdx
+++ b/src/content/reviews/fr/oncle-lee-kao-montreal.mdx
@@ -2,7 +2,7 @@
 title: "Oncle Lee Kăo : Grill Chinois à Montréal"
 lang: fr
 translationSlug: oncle-lee-kao-montreal
-description: "Oncle Lee Kăo, Bib Gourmand Michelin, propose le grill chinois contemporain en plein coeur du Vieux-Montréal : assiettes à partager et ambiance soignée."
+description: "Avis Oncle Lee Kăo : Bib Gourmand Michelin et grill chinois au Vieux-Montréal. Assiettes fumées à partager, grande salle et soirée en amoureux réussie."
 author: "Victor"
 publishDate: 2026-07-02
 heroImage: "../../../assets/images/reviews/oncle-lee-kao-montreal.jpg"

--- a/src/content/reviews/fr/othym-montreal.mdx
+++ b/src/content/reviews/fr/othym-montreal.mdx
@@ -2,7 +2,7 @@
 title: "Othym : La Table BYOB Saisonnière de Montréal"
 lang: fr
 translationSlug: othym-montreal
-description: "Recommandé par Michelin, Othym sert les saisons québécoises en BYOB dans le Village. Cadre détendu, assiettes ancrées dans le terroir, valeur honnête."
+description: "Avis O-Thym : bistrot BYOB recommandé Michelin dans le Village de Montréal. Cuisine de saison québécoise, prix honnêtes et cadre intime pour un souper."
 author: "Victor"
 publishDate: 2026-06-25
 heroImage: "../../../assets/images/reviews/othym-montreal.jpg"


### PR DESCRIPTION
## Summary

Automated weekly SEO maintenance run for 2026-07-19.

**Audit result:** All 19 recipes and 15 articles pass source validation. Titles, descriptions, translation pairs, tag parity, and Picture fallbackFormat all clean.

**Description optimizations (Step 3):** Updated meta descriptions for the 3 highest-impression underperformers from the 2026-07-13 rankings snapshot:

| Page | Impressions | Old CTR | Change |
|------|------------|---------|--------|
| `oncle-lee-kao-montreal` | 129 | 1.6% (pos 9-10) | Led with "review" keyword, named Michelin Bib Gourmand + Chinese grill upfront |
| `othym-montreal` | 38 | 0% (pos 10) | Added "O-Thym" hyphenated variant (top search query), Michelin + BYOB angle |
| `best-cutting-board-material` | 36 | 2.8% (pos 4-12) | Named Katori and Hasegawa explicitly (top searched terms on the page) |

EN and FR pairs updated for all three. Descriptions validated 120-160 chars via `node scripts/validate-descriptions.mjs`.

**Internal links (Step 4):** Skipped. No new recipe/article pages were published in the last 7 days (Moccione update was images/captions only, not a new page).

## Content gaps to queue in Notion

None identified this run.


---
_Generated by [Claude Code](https://claude.ai/code/session_01L1hgjScvqCa1YKUATxHjP6)_