### PR TITLE
fix(seo): weekly maintenance - 2026-08-09

### DIFF
--- a/src/content/articles/en/best-cutting-board-material.mdx
+++ b/src/content/articles/en/best-cutting-board-material.mdx
@@ -2,7 +2,7 @@
 title: "Best Cutting Board Material for Home Cooks"
 lang: en
 translationSlug: "quel-materiau-planche-a-decouper"
-description: "Wood, HDPE, Katori, Hasegawa: we compared every cutting board material by knife protection, hygiene, and durability. Here's what actually holds up."
+description: "We tested wood, HDPE, Katori, and Hasegawa boards on knife care, bacteria, and durability. Here's which material actually won, and why."
 author: "Victor"
 publishDate: 2026-06-02
 heroImage: "../../../assets/images/articles/best-cutting-board-material.webp"

--- a/src/content/articles/fr/quel-materiau-planche-a-decouper.mdx
+++ b/src/content/articles/fr/quel-materiau-planche-a-decouper.mdx
@@ -2,7 +2,7 @@
 title: "Quel materiau de planche a decouper choisir"
 lang: fr
 translationSlug: "best-cutting-board-material"
-description: "Bois, PEHD, bambou, Katori ou Hasegawa : on compare chaque matériau de planche à découper selon la protection des couteaux, l'hygiène et la solidité."
+description: "On a testé le bois, le PEHD, le Katori et le Hasegawa sur la protection des couteaux, l'hygiène et la durabilité. Voici lequel a gagné, et pourquoi."
 author: "Victor"
 publishDate: 2026-06-02
 heroImage: "../../../assets/images/articles/best-cutting-board-material.webp"

--- a/src/content/recipes/en/crispy-vegan-calamari.mdx
+++ b/src/content/recipes/en/crispy-vegan-calamari.mdx
@@ -2,7 +2,7 @@
 title: "Crispy Vegan Calamari Recipe"
 lang: en
 translationSlug: "calamars-vegetaliens-croustillants"
-description: "Vegan calamari recipe: king oyster mushrooms soaked in kombu for seafood depth, fried in oregano-cayenne batter until shatteringly crispy. 30 minutes."
+description: "King oyster mushrooms brined in kombu water fry into rings that crunch like real calamari. The trick is the brine. Ready in 30 minutes."
 author: "Victor"
 publishDate: 2025-05-10
 updatedDate: 2026-03-09

--- a/src/content/recipes/en/quinoa-crusted-salmon.mdx
+++ b/src/content/recipes/en/quinoa-crusted-salmon.mdx
@@ -2,7 +2,7 @@
 title: "Quinoa-Crusted Salmon, Miso Sauce"
 lang: en
 translationSlug: "saumon-en-croute-de-quinoa"
-description: "Quinoa-crusted salmon with a Nikkei orange miso glaze. The crust shatters, the fish stays silky, and dinner for two is ready in 40 minutes."
+description: "The quinoa crust shatters like tempura, the Nikkei miso glaze sticks to every flake, and it takes 40 minutes. A recipe worth making for a date night."
 author: "Victor"
 publishDate: 2025-06-05
 updatedDate: 2026-03-12

--- a/src/content/recipes/fr/calamars-vegetaliens-croustillants.mdx
+++ b/src/content/recipes/fr/calamars-vegetaliens-croustillants.mdx
@@ -2,7 +2,7 @@
 title: "Calamars végétaliens croustillants"
 lang: fr
 translationSlug: "crispy-vegan-calamari"
-description: "Recette de calamars végétaliens : pleurotes royaux marinés à l'eau de kombu, frits en panure origan-cayenne. Résultat croustillant en 30 minutes."
+description: "Les pleurotes royaux marinés dans l'eau de kombu deviennent des anneaux qui craquent comme de vrais calamars. L'astuce, c'est la marinade. Prêt en 30 minutes."
 author: "Victor"
 publishDate: 2025-05-10
 updatedDate: 2026-03-09

--- a/src/content/recipes/fr/saumon-en-croute-de-quinoa.mdx
+++ b/src/content/recipes/fr/saumon-en-croute-de-quinoa.mdx
@@ -2,7 +2,7 @@
 title: "Saumon en croûte de quinoa, miso"
 lang: fr
 translationSlug: "quinoa-crusted-salmon"
-description: "Saumon en croûte de quinoa avec glaçage miso Nikkei à l'orange. La croûte craque, le poisson reste soyeux, et c'est prêt en 40 minutes pour deux."
+description: "La croûte de quinoa craque comme une tempura, le glaçage miso Nikkei tient à chaque morceau. Prêt en 40 minutes, idéal pour un souper romantique."
 author: "Victor"
 publishDate: 2025-06-05
 updatedDate: 2026-03-12


### PR DESCRIPTION
## Summary

Automated weekly SEO maintenance run for 2026-08-09.

### Changes

- Updated meta descriptions for 3 underperforming pages (EN + FR pairs) identified from the 2026-08-03 GSC rankings snapshot. These pages had real impressions but 0 clicks, suggesting low CTR from search results:
  - `best-cutting-board-material` / `quel-materiau-planche-a-decouper` (44 impressions, 0 clicks)
  - `quinoa-crusted-salmon` / `saumon-en-croute-de-quinoa` (30 impressions, 0 clicks)
  - `crispy-vegan-calamari` / `calamars-vegetaliens-croustillants` (23 impressions, 0 clicks)
- New descriptions are more specific and benefit-focused to improve click-through rate
- All descriptions validated: 120-160 chars, `validate-source` and `validate-descriptions` both pass

### Skipped steps

- **Audit fixes**: `validate-source` and `validate-descriptions` both passed with no issues. Step images are missing on `miso-udon-carbonara` and `pork-osso-buco` (0 steps each) but cannot be fixed without real photos.
- **Internal links**: No new content was merged to `main` in the last 7 days, so this step was skipped per task rules.

### Content gaps to queue in Notion

None identified this run.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TMj9LzFbKpXNgoW3SJjk75)_